### PR TITLE
feat: knowhow 관련기능 유저 연동

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "typescript.preferences.importModuleSpecifier": "non-relative"
+}

--- a/src/app/(main)/boards/_components/Comments/CommentActions.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentActions.tsx
@@ -1,0 +1,19 @@
+type CommentActionsProps = {
+  onOpenModal: () => void;
+  onEditModeChange: () => void;
+};
+
+function CommentActions({ onOpenModal: handleOpenModal, onEditModeChange: handleEditModeChange }: CommentActionsProps) {
+  return (
+    <div className="flex gap-2">
+      <span className="cursor-pointer" onClick={handleEditModeChange}>
+        수정
+      </span>
+      <span className="cursor-pointer" onClick={handleOpenModal}>
+        삭제
+      </span>
+    </div>
+  );
+}
+
+export default CommentActions;

--- a/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
@@ -1,0 +1,28 @@
+import Button from "@/components/Button/Button";
+import { TKnowhowComment } from "@/types/knowhow.type";
+import { ChangeEventHandler } from "react";
+
+type CommentEditFormProps = {
+  editedContent: TKnowhowComment["content"];
+  onContentChange: ChangeEventHandler<HTMLTextAreaElement>;
+  onCommentUpdate: () => void;
+};
+
+function CommentEditForm({
+  editedContent,
+  onContentChange: handleContentChange,
+  onCommentUpdate: handleCommentUpdate
+}: CommentEditFormProps) {
+  return (
+    <form>
+      <textarea className=" border resize-none w-full" value={editedContent} onChange={handleContentChange} />
+      <div className="flex justify-end">
+        <Button type="button" onClick={handleCommentUpdate}>
+          수정완료
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default CommentEditForm;

--- a/src/app/(main)/boards/_components/Comments/CommentForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Button from "@/components/Button/Button";
+import { useUserContext } from "@/provider/contexts/userContext";
 import useKnowhowCommentMutation from "@/stores/queries/useKnowhowCommentMutation";
 import { FormEventHandler, useRef } from "react";
 
@@ -8,15 +9,16 @@ type CommentFormProps = {
 };
 
 function CommentForm({ postId }: CommentFormProps) {
+  const { user } = useUserContext();
   const { addKnowhowComment } = useKnowhowCommentMutation();
   const commentInputRef = useRef<HTMLTextAreaElement>(null);
 
   const handleCommentSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
-    if (commentInputRef.current && postId) {
+    if (commentInputRef.current && postId && user) {
       const newComment = {
         content: commentInputRef.current?.value,
-        user_id: "a16e76cd-30fb-4130-b321-ec457d17783c",
+        user_id: user.userId,
         knowhow_post_id: postId
       };
       await addKnowhowComment(newComment);

--- a/src/app/(main)/boards/_components/Comments/CommentItem.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentItem.tsx
@@ -3,14 +3,17 @@ import { TKnowhowComment } from "@/types/knowhow.type";
 import { formatTime } from "@/app/(main)/boards/_utils";
 import useKnowhowCommentMutation from "@/stores/queries/useKnowhowCommentMutation";
 import { ChangeEventHandler, useState } from "react";
-import Button from "@/components/Button/Button";
 import { useModal } from "@/provider/contexts/modalContext";
+import { useUserContext } from "@/provider/contexts/userContext";
+import CommentActions from "./CommentActions";
+import CommentEditForm from "./CommentEditForm";
 
 type CommentItemProps = {
   comment: TKnowhowComment;
 };
 
 function CommentItem({ comment }: CommentItemProps) {
+  const { user } = useUserContext();
   const modal = useModal();
   const { nickname, content, created_at } = comment;
   const [isEditting, setIsEditting] = useState<boolean>(false);
@@ -24,9 +27,11 @@ function CommentItem({ comment }: CommentItemProps) {
       content: "댓글을 삭제하시겠습니까?",
       onConfirm: handleCommentDelete
     });
+  const handleEditModeChange = () => setIsEditting(true);
   const handleContentChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => setEditedContent(e.target.value);
   const handleCommentDelete = () => removeKnowhowComment(comment);
   const handleCommentUpdate = async () => {
+    ``;
     const { nickname, ...commentWithoutNickname } = comment;
     const updatedComment = {
       ...commentWithoutNickname,
@@ -40,15 +45,8 @@ function CommentItem({ comment }: CommentItemProps) {
     <li className="mt-4 border rounded-xl px-5">
       <div className="flex justify-between">
         <span>{nickname}</span>
-        {!isEditting && (
-          <div className="flex gap-2">
-            <span className="cursor-pointer" onClick={() => setIsEditting(true)}>
-              수정
-            </span>
-            <span className="cursor-pointer" onClick={handleOpenModal}>
-              삭제
-            </span>
-          </div>
+        {!isEditting && user?.userId === comment?.user_id && (
+          <CommentActions onEditModeChange={handleEditModeChange} onOpenModal={handleOpenModal} />
         )}
       </div>
       {!isEditting && (
@@ -61,12 +59,11 @@ function CommentItem({ comment }: CommentItemProps) {
         </>
       )}
       {isEditting && (
-        <div className="">
-          <textarea className=" border resize-none w-full" value={editedContent} onChange={handleContentChange} />
-          <div className="flex justify-end">
-            <Button onClick={handleCommentUpdate}>수정완료</Button>
-          </div>
-        </div>
+        <CommentEditForm
+          editedContent={editedContent}
+          onContentChange={handleContentChange}
+          onCommentUpdate={handleCommentUpdate}
+        />
       )}
     </li>
   );

--- a/src/app/(main)/boards/knowhow/[knowhowId]/_components/ActionNav.tsx
+++ b/src/app/(main)/boards/knowhow/[knowhowId]/_components/ActionNav.tsx
@@ -1,17 +1,20 @@
 "use client";
 import Button from "@/components/Button/Button";
 import { useModal } from "@/provider/contexts/modalContext";
+import { useUserContext } from "@/provider/contexts/userContext";
 import useKnowhowMutation from "@/stores/queries/useKnowhowMutation";
+import { TKnowhow } from "@/types/knowhow.type";
 
 type ActionNavProps = {
-  knowhowId: number;
+  knowhow: TKnowhow;
 };
 
-function ActionNav({ knowhowId }: ActionNavProps) {
+function ActionNav({ knowhow }: ActionNavProps) {
   const modal = useModal();
+  const { user } = useUserContext();
   const { removeKnowhow } = useKnowhowMutation();
   const handleDeleteKnowhow = async () => {
-    await removeKnowhow(knowhowId);
+    await removeKnowhow(knowhow.knowhow_postId);
   };
 
   const handleOpenModal = () =>
@@ -24,8 +27,12 @@ function ActionNav({ knowhowId }: ActionNavProps) {
 
   return (
     <nav className="flex gap-1">
-      <Button href={`/boards/knowhow/edit/${knowhowId}`}>수정</Button>
-      <Button onClick={handleOpenModal}>삭제</Button>
+      {user?.userId === knowhow.user_id && (
+        <>
+          <Button href={`/boards/knowhow/edit/${knowhow.knowhow_postId}`}>수정</Button>
+          <Button onClick={handleOpenModal}>삭제</Button>{" "}
+        </>
+      )}
 
       <Button href="/boards/knowhow">목록으로</Button>
     </nav>

--- a/src/app/(main)/boards/knowhow/[knowhowId]/_components/PostActions.tsx
+++ b/src/app/(main)/boards/knowhow/[knowhowId]/_components/PostActions.tsx
@@ -1,16 +1,17 @@
 "use client";
 import KnowhowLikes from "./KnowhowLikes";
 import ActionNav from "./ActionNav";
+import { TKnowhow } from "@/types/knowhow.type";
 
 type PostActionsProps = {
-  knowhowId: number;
+  knowhow: TKnowhow;
 };
 
-function PostActions({ knowhowId }: PostActionsProps) {
+function PostActions({ knowhow }: PostActionsProps) {
   return (
     <section className="flex gap-1 items-center">
-      <KnowhowLikes knowhowId={knowhowId} />
-      <ActionNav knowhowId={knowhowId} />
+      <KnowhowLikes knowhowId={knowhow.knowhow_postId} />
+      <ActionNav knowhow={knowhow} />
     </section>
   );
 }

--- a/src/app/(main)/boards/knowhow/[knowhowId]/page.tsx
+++ b/src/app/(main)/boards/knowhow/[knowhowId]/page.tsx
@@ -9,7 +9,7 @@ async function KnowhowDetailPage({ params: { knowhowId } }: { params: { knowhowI
   return (
     <main>
       <PostContent knowhow={knowhow} />
-      <PostActions knowhowId={knowhowId} />
+      <PostActions knowhow={knowhow} />
       <CommentsContainer postId={knowhowId} />
     </main>
   );

--- a/src/app/(main)/boards/knowhow/_components/KnowhowEditor.tsx
+++ b/src/app/(main)/boards/knowhow/_components/KnowhowEditor.tsx
@@ -8,6 +8,7 @@ import ReactQuill, { ReactQuillProps } from "react-quill";
 import useKnowhowImageMutation from "@/stores/queries/useKnowhowImageMutation";
 import useKnowhowMutation from "@/stores/queries/useKnowhowMutation";
 import { TKnowhow } from "@/types/knowhow.type";
+import { useUserContext } from "@/provider/contexts/userContext";
 
 type ForwardedQuillComponent = ReactQuillProps & {
   forwardedRef: React.Ref<ReactQuill>;
@@ -61,6 +62,7 @@ const formats = [
 ];
 
 function KnowhowEditor({ previousContent, revalidate }: KnowhowEditorProps) {
+  const { user } = useUserContext();
   const { addKnowhowImage } = useKnowhowImageMutation();
   const { addKnowhow, updateKnowhow } = useKnowhowMutation(revalidate);
   const quillRef = useRef<ReactQuill>(null);
@@ -136,21 +138,24 @@ function KnowhowEditor({ previousContent, revalidate }: KnowhowEditorProps) {
       }
     }
 
-    const newKnowhow = {
-      title: editorTitle,
-      content,
-      image_urls: imageUrls,
-      user_id: "a16e76cd-30fb-4130-b321-ec457d17783c"
-    };
+    if (user) {
+      console.log(user);
+      const newKnowhow = {
+        title: editorTitle,
+        content,
+        image_urls: imageUrls,
+        user_id: user.userId
+      };
 
-    try {
-      if (previousContent) {
-        const res = await updateKnowhow({ ...newKnowhow, knowhow_postId: previousContent.knowhow_postId });
-      } else {
-        await addKnowhow(newKnowhow);
+      try {
+        if (previousContent) {
+          const res = await updateKnowhow({ ...newKnowhow, knowhow_postId: previousContent.knowhow_postId });
+        } else {
+          await addKnowhow(newKnowhow);
+        }
+      } catch (error) {
+        console.log(error);
       }
-    } catch (error) {
-      console.log(error);
     }
   };
 


### PR DESCRIPTION
## 변경 사항:

- 게시글 작성, 수정시 현재 유저의 id를 받아와서 작성되도록 변경
- 댓글 작성, 수정시 현재 유저의 id를 받아와서 작성되도록 변경
- 상세 페이지에서 현재 유저가 글 작성자가 아니라면 수정, 삭제버튼이 보이지 않도록 변경
- 상세 페이지에서 현재 유저가 댓글 작성자가 아니라면 수정, 삭제버튼이 보이지 않도록 변경
- 자동 import 시 절대경로로 import 하도록 설정

## 변경 유형

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [ ] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [x] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [x] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈

- close #56 
