### PR TITLE
feat/vote-comments 짠 소비 상세 페이지 좌우 버튼 구현

### DIFF
--- a/src/apis/votes.ts
+++ b/src/apis/votes.ts
@@ -1,5 +1,5 @@
 import { BASE_URL } from "@/constants";
-import { TVotesResponse } from "@/types/vote.type";
+import { TVotesResponse, TVoteWithNavigation } from "@/types/vote.type";
 import { TVote } from "@/types/vote.type";
 import { Tables } from "@/types/supabase";
 
@@ -9,9 +9,12 @@ export const getVotes = async (sortOrder: string, page: number) => {
   return votes;
 };
 
-export const getVote = async (voteId: TVote["vote_postId"]) => {
+export const getVote = async (voteId: number): Promise<TVoteWithNavigation> => {
   const res = await fetch(`${BASE_URL}/api/votes/${voteId}`, { cache: "no-store" });
-  const vote: TVote = await res.json();
+  if (!res.ok) {
+    throw new Error("Failed to fetch vote data");
+  }
+  const vote: TVoteWithNavigation = await res.json();
   return vote;
 };
 

--- a/src/app/(main)/boards/votes/[voteId]/_components/NavButton.tsx
+++ b/src/app/(main)/boards/votes/[voteId]/_components/NavButton.tsx
@@ -7,7 +7,15 @@ type NavButtonProps = {
 function NavButton({ direction }: NavButtonProps) {
   const text = direction === "next" ? ">" : "<";
 
-  return <button className="bg-white text-black p-2 rounded-full">{text}</button>;
+  return (
+    <div className="w-[74px] h-[74px] relative bg-white rounded-[74px] border border-[#1b1b1b]">
+      {direction === "next" ? (
+        <div className="w-[15px] h-[15px] left-[35px] top-[26.39px] absolute origin-top-left rotate-45 border-r border-t border-[#1b1b1b]" />
+      ) : (
+        <div className="w-[15px] h-[15px] left-[39px] top-[47.61px] absolute origin-top-left rotate-[-135deg] border-r border-t border-[#1b1b1b]" />
+      )}
+    </div>
+  );
 }
 
 export default NavButton;

--- a/src/app/(main)/boards/votes/[voteId]/_components/NavButton.tsx
+++ b/src/app/(main)/boards/votes/[voteId]/_components/NavButton.tsx
@@ -1,20 +1,38 @@
 "use client";
 
+import { TVoteWithNavigation } from "@/types/vote.type";
+import { useRouter, useSearchParams } from "next/navigation";
+
 type NavButtonProps = {
-  direction: string;
+  vote: TVoteWithNavigation;
+  direction: "next" | "prev";
 };
 
-function NavButton({ direction }: NavButtonProps) {
-  const text = direction === "next" ? ">" : "<";
+function NavButton({ vote, direction }: NavButtonProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const sortOrder = searchParams.get("sortOrder") || "latest";
+
+  const targetVoteId = direction === "next" ? vote.nextVoteId : vote.prevVoteId;
+
+  const handleClick = () => {
+    if (targetVoteId) {
+      router.push(`/boards/votes/${targetVoteId}?sortOrder=${sortOrder}`);
+    }
+  };
 
   return (
-    <div className="w-[74px] h-[74px] relative bg-white rounded-[74px] border border-[#1b1b1b]">
+    <button
+      className="w-[74px] h-[74px] relative bg-white rounded-[74px] border border-[#1b1b1b] cursor-pointer"
+      onClick={handleClick}
+      disabled={!targetVoteId}
+    >
       {direction === "next" ? (
         <div className="w-[15px] h-[15px] left-[35px] top-[26.39px] absolute origin-top-left rotate-45 border-r border-t border-[#1b1b1b]" />
       ) : (
         <div className="w-[15px] h-[15px] left-[39px] top-[47.61px] absolute origin-top-left rotate-[-135deg] border-r border-t border-[#1b1b1b]" />
       )}
-    </div>
+    </button>
   );
 }
 

--- a/src/app/(main)/boards/votes/[voteId]/_components/VoteContent.tsx
+++ b/src/app/(main)/boards/votes/[voteId]/_components/VoteContent.tsx
@@ -3,6 +3,7 @@
 import NavButton from "@/app/(main)/boards/votes/[voteId]/_components/NavButton";
 import VoteButtons from "@/app/(main)/boards/votes/[voteId]/_components/VoteButtons";
 import { TVote } from "@/types/vote.type";
+import Image from "next/image";
 
 type VoteContentProps = {
   vote: TVote;
@@ -13,9 +14,12 @@ function VoteContent({ vote }: VoteContentProps) {
 
   return (
     <section>
-      <NavButton direction="prev" />
-      <div>{title}</div>
-      {/* 아래 div 디자인 확정되면 수정할 것 */}
+      <NavButton vote={vote} direction="prev" />
+      <div>
+        {title}
+        {/* 테스트용 */}
+        {vote_postId}
+      </div>
       <div>
         <div>
           <span>{product_name}</span>
@@ -24,11 +28,11 @@ function VoteContent({ vote }: VoteContentProps) {
         <div>{nickname}</div>
       </div>
       <div>
-        <img src={image_url} alt="게시글 이미지" className="w-32 h-32 object-cover" />
+        {/* <Image src={image_url} alt="게시글 이미지" className="w-32 h-32 object-cover" width={128} height={128} /> */}
       </div>
       <VoteButtons voteId={vote_postId} />
       <div>{content}</div>
-      <NavButton direction="next" />
+      <NavButton vote={vote} direction="next" />
     </section>
   );
 }

--- a/src/app/(main)/boards/votes/_components/VoteItem.tsx
+++ b/src/app/(main)/boards/votes/_components/VoteItem.tsx
@@ -6,24 +6,27 @@ type voteItemProps = {
   vote: TVote;
 };
 
-function VoteItem({ vote }: voteItemProps) {
+function VoteItem({ vote, sortOrder }: voteItemProps & { sortOrder: string }) {
   const { vote_postId, image_url, title, nickname, votes_count, comments_count } = vote;
-
   return (
     <li className="w-[252px] h-[310px] shadow flex-col justify-start items-center inline-flex">
-      <Link href={`/boards/votes/${vote_postId}`}>
+      <Link href={`/boards/votes/${vote_postId}?sortOrder=${sortOrder}`}>
         <div className="w-[252px] h-[310px] shadow flex-col justify-start items-center inline-flex">
           <div className="relative w-[252px] h-[155px]">
-            <Image
+            {/* <Image
               className="grow shrink basis-0"
               src={image_url}
               alt="게시글 이미지"
               layout="fill"
               objectFit="cover"
-            />
+            /> */}
           </div>
           <div className="self-stretch grow shrink basis-0 flex-col justify-start items-start p-3 bg-gray-100 gap-2 flex">
-            <div className="self-stretch h-[59px] text-black text-xl font-semibold leading-7 truncate">{title}</div>
+            <div className="self-stretch h-[59px] text-black text-xl font-semibold leading-7 truncate">
+              {title}
+              {/* 테스트용 */}
+              {vote_postId}
+            </div>
             <div className="self-stretch text-[#000000] text-sm font-normal leading-tight">{nickname}</div>
           </div>
           <div className="self-stretch grow shrink basis-0 px-2 bg-gray-900 justify-start items-center gap-3 flex">

--- a/src/app/(main)/boards/votes/_components/VotesContainer.tsx
+++ b/src/app/(main)/boards/votes/_components/VotesContainer.tsx
@@ -10,11 +10,12 @@ import { useRouter } from "next/navigation";
 function VotesContainer() {
   const router = useRouter();
   const [sortOrder, setSortOrder] = useState("latest");
+
   const { data, isLoading, fetchNextPage, hasNextPage } = useVotesQuery(sortOrder);
   const observer = useRef<IntersectionObserver | null>(null);
 
   const handleWriteClick = () => {
-    router.push("/boards/votes/write");
+    router.push(`/boards/votes/write`);
   };
 
   const handleSortOrderChange = (order: string) => {
@@ -49,7 +50,11 @@ function VotesContainer() {
     <section>
       <Button onClick={handleWriteClick}>글쓰기</Button>
       <SortButtons sortOrder={sortOrder} handleSortOrderChange={handleSortOrderChange} />
-      <VotesList votes={data?.pages.flatMap((page) => page.data)} lastVoteElementRef={lastVoteElementRef} />
+      <VotesList
+        votes={data?.pages.flatMap((page) => page.data)}
+        lastVoteElementRef={lastVoteElementRef}
+        sortOrder={sortOrder}
+      />
     </section>
   );
 }

--- a/src/app/(main)/boards/votes/_components/VotesList.tsx
+++ b/src/app/(main)/boards/votes/_components/VotesList.tsx
@@ -6,7 +6,7 @@ type VotesListProps = {
   lastVoteElementRef: (node: HTMLDivElement) => void;
 };
 
-function VotesList({ votes, lastVoteElementRef }: VotesListProps) {
+function VotesList({ votes, lastVoteElementRef, sortOrder }: VotesListProps & { sortOrder: string }) {
   return (
     // 한 줄에 카드를 세 개까지만 보여주는 문제
     <ul className="self-stretch justify-start items-center gap-9 flex flex-wrap">
@@ -14,7 +14,7 @@ function VotesList({ votes, lastVoteElementRef }: VotesListProps) {
         const isLastElement = votes.length === index + 1;
         return (
           <div ref={isLastElement ? lastVoteElementRef : null} key={vote.vote_postId}>
-            <VoteItem vote={vote} />
+            <VoteItem vote={vote} sortOrder={sortOrder} />
           </div>
         );
       })}

--- a/src/app/api/votes/[voteId]/route.ts
+++ b/src/app/api/votes/[voteId]/route.ts
@@ -1,35 +1,53 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/utils/supabase/server";
 
-export async function GET(req: NextRequest, { params: { voteId } }: { params: { voteId: number } }) {
+export async function GET(req: NextRequest, { params: { voteId } }: { params: { voteId: string } }) {
   const supabase = createClient();
+  const voteIdNumber = Number(voteId);
+  const sortOrder = req.nextUrl.searchParams.get("sortOrder");
+
+  const sortBy = sortOrder === "votes" ? "votes_count" : "created_at";
 
   try {
-    if (voteId) {
-      const { data, error } = await supabase
-        .from("vote_posts")
-        .select(
-          `
+    const { data, error } = await supabase
+      .from("vote_posts")
+      .select(
+        `
           *,
           users (nickname)
         `
-        )
-        .eq("vote_postId", voteId)
-        .single();
+      )
+      .eq("vote_postId", voteIdNumber)
+      .single();
 
-      if (error || !data) {
-        throw new Error("게시글을 불러오지 못했습니다.");
-      }
-
-      const { users, ...voteData } = data;
-
-      const result = {
-        ...voteData,
-        nickname: users?.nickname
-      };
-
-      return NextResponse.json(result);
+    if (error || !data) {
+      throw new Error("게시글을 불러오지 못했습니다.");
     }
+
+    const { users, ...voteData } = data;
+
+    const result = {
+      ...voteData,
+      nickname: users?.nickname
+    };
+
+    // 투표수 순으로 정렬했을 때 prevVoteId, nextVoteId를 어떻게 구할 것인가?
+    // ↓ 극히 비효율적인 방법
+    // 게시글 이동 버튼에 대해 상의 후 수정할 것
+    const { data: allVotes, error: navigationError } = await supabase
+      .from("vote_posts")
+      .select("vote_postId")
+      .order(sortBy, { ascending: sortBy === "votes_count" });
+
+    if (navigationError || !allVotes) {
+      throw new Error("네비게이션 데이터를 불러오지 못했습니다.");
+    }
+
+    const currentIndex = allVotes.findIndex((vote) => vote.vote_postId === voteIdNumber);
+    let prevVoteId = currentIndex > 0 ? allVotes[currentIndex - 1].vote_postId : null;
+    let nextVoteId = currentIndex < allVotes.length - 1 ? allVotes[currentIndex + 1].vote_postId : null;
+
+    return NextResponse.json({ ...result, prevVoteId, nextVoteId });
   } catch (e) {
     if (e instanceof Error) {
       return NextResponse.json({ error: e.message }, { status: 500 });
@@ -38,10 +56,9 @@ export async function GET(req: NextRequest, { params: { voteId } }: { params: { 
   }
 }
 
-export const PATCH = async (req: NextRequest, { params }: { params: { voteId: number } }) => {
+export const PATCH = async (req: NextRequest, { params }: { params: { voteId: string } }) => {
   const supabase = createClient();
-
-  const voteId = params.voteId;
+  const voteId = Number(params.voteId);
   const updatedVote = await req.json();
 
   try {
@@ -59,10 +76,10 @@ export const PATCH = async (req: NextRequest, { params }: { params: { voteId: nu
   }
 };
 
-export const DELETE = async (req: NextRequest, { params }: { params: { voteId: number } }) => {
+export const DELETE = async (req: NextRequest, { params }: { params: { voteId: string } }) => {
   const supabase = createClient();
+  const voteId = Number(params.voteId);
 
-  const voteId = params.voteId;
   try {
     if (voteId) {
       const { status, statusText, error } = await supabase.from("vote_posts").delete().eq("vote_postId", voteId);

--- a/src/app/api/votes/posts/route.ts
+++ b/src/app/api/votes/posts/route.ts
@@ -8,16 +8,17 @@ export const GET = async (req: Request) => {
   const page = parseInt(url.searchParams.get("page") || "0");
   const pageSize = 12;
 
+  let sortBy = "created_at";
+  let order = "desc";
+
+  if (sortOrder === "votes") {
+    sortBy = "votes_count";
+  }
+
   try {
-    let query = supabase.rpc("get_votes_with_counts_and_nickname").range(page * pageSize, (page + 1) * pageSize - 1);
-
-    if (sortOrder === "latest") {
-      query = query.order("created_at", { ascending: false });
-    } else if (sortOrder === "votes") {
-      query = query.order("votes_count", { ascending: false });
-    }
-
-    const { data, error } = await query;
+    const { data, error } = await supabase
+      .rpc("get_votes_with_counts_and_nickname", { sort_by: sortBy, sort_order: order })
+      .range(page * pageSize, (page + 1) * pageSize - 1);
 
     if (error) {
       throw new Error("게시글을 불러오지 못했습니다.");

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -566,7 +566,10 @@ export type Database = {
         }[];
       };
       get_votes_with_counts_and_nickname: {
-        Args: Record<PropertyKey, never>;
+        Args: {
+          sort_by: string;
+          sort_order: string;
+        };
         Returns: {
           vote_postId: number;
           title: string;

--- a/src/types/vote.type.ts
+++ b/src/types/vote.type.ts
@@ -17,3 +17,8 @@ export type TVoteLikeCountsResponse = {
   downvoteCount: number;
   userLikeStatus: boolean | null;
 };
+
+export type TVoteWithNavigation = TVote & {
+  prevVoteId?: number | null;
+  nextVoteId?: number | null;
+};


### PR DESCRIPTION
## 변경 사항:

-  짠 소비 상세 페이지 좌우 버튼 UI
- 짠 소비 상세 페이지 좌우 버튼 기능 구현
- 짠 소비를 투표수 순으로 정렬했을 때에도 버튼 클릭 시 최신 순으로 이동하는 이슈가 있습니다. 이 부분 상의 후 수정하고자 합니다🙇‍♂️

## 변경 유형

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [ ] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [x] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [x] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈

- close #102 
