### PR TITLE
feat/vote-comments 짠 소비 상세 페이지 댓글 구현 

### DIFF
--- a/src/apis/votes.ts
+++ b/src/apis/votes.ts
@@ -65,6 +65,61 @@ export const deleteVote = async (voteId: Tables<"vote_posts">["vote_postId"]) =>
   return vote;
 };
 
+export const getVoteComments = async (voteId: TVote["vote_postId"]) => {
+  const res = await fetch(`${BASE_URL}/api/votes/${voteId}/comments`);
+  const data = await res.json();
+  const comments = data.comments;
+  return comments;
+};
+
+export const postVoteComment = async (newComment: Partial<Tables<"vote_comments">>) => {
+  const res = await fetch(`${BASE_URL}/api/votes/${newComment.vote_post_id}/comments`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(newComment)
+  });
+  if (!res.ok) {
+    const errorData = await res.json();
+    const errorMessage = errorData.error || "댓글 작성에 실패했습니다.";
+    throw new Error(errorMessage);
+  }
+  const data = await res.json();
+  return data;
+};
+
+export const patchVoteComment = async (updatedComment: Partial<Tables<"vote_comments">>) => {
+  const res = await fetch(`${BASE_URL}/api/votes/comments/${updatedComment.vote_commentId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(updatedComment)
+  });
+  if (!res.ok) {
+    const errorData = await res.json();
+    const errorMessage = errorData.error || "댓글 수정에 실패했습니다.";
+    throw new Error(errorMessage);
+  }
+
+  const data = await res.json();
+  return data;
+};
+
+export const deleteVoteComment = async (commentId: Tables<"vote_comments">["vote_commentId"]) => {
+  const res = await fetch(`${BASE_URL}/api/votes/comments/${commentId}`, {
+    method: "DELETE"
+  });
+  if (!res.ok) {
+    const errorData = await res.json();
+    const errorMessage = errorData.error || "댓글 삭제에 실패했습니다.";
+    throw new Error(errorMessage);
+  }
+  const data = await res.json();
+  return data;
+};
+
 export const getVoteLikesData = async (voteId: TVote["vote_postId"]) => {
   const res = await fetch(`${BASE_URL}/api/votes/${voteId}/like`);
   if (!res.ok) {
@@ -73,6 +128,5 @@ export const getVoteLikesData = async (voteId: TVote["vote_postId"]) => {
     throw new Error(errorMessage);
   }
   const data = await res.json();
-
   return data;
 };

--- a/src/app/(main)/boards/_components/Comments/CommentActions.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentActions.tsx
@@ -6,10 +6,10 @@ type CommentActionsProps = {
 function CommentActions({ onOpenModal: handleOpenModal, onEditModeChange: handleEditModeChange }: CommentActionsProps) {
   return (
     <div className="flex gap-2">
-      <span className="cursor-pointer" onClick={handleEditModeChange}>
+      <span className="cursor-pointer text-[#acacac] text-sm font-normal leading-3" onClick={handleEditModeChange}>
         수정
       </span>
-      <span className="cursor-pointer" onClick={handleOpenModal}>
+      <span className="cursor-pointer text-[#acacac] text-sm font-normal leading-3" onClick={handleOpenModal}>
         삭제
       </span>
     </div>

--- a/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
@@ -1,9 +1,10 @@
 import Button from "@/components/Button/Button";
 import { TKnowhowComment } from "@/types/knowhow.type";
+import { TVoteComment } from "@/types/vote.type";
 import { ChangeEventHandler } from "react";
 
 type CommentEditFormProps = {
-  editedContent: TKnowhowComment["content"];
+  editedContent: TKnowhowComment["content"] | TVoteComment["content"];
   onContentChange: ChangeEventHandler<HTMLTextAreaElement>;
   onCommentUpdate: () => void;
 };

--- a/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
@@ -15,8 +15,12 @@ function CommentEditForm({
   onCommentUpdate: handleCommentUpdate
 }: CommentEditFormProps) {
   return (
-    <form>
-      <textarea className=" border resize-none w-full" value={editedContent} onChange={handleContentChange} />
+    <form className="w-full flex flex-col gap-3">
+      <textarea
+        className="border border-[#DCDCDC] rounded-xl resize-none w-full h-[118px] mb-4"
+        value={editedContent}
+        onChange={handleContentChange}
+      />
       <div className="flex justify-end">
         <Button type="button" onClick={handleCommentUpdate}>
           수정완료

--- a/src/app/(main)/boards/_components/Comments/CommentForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentForm.tsx
@@ -1,9 +1,11 @@
 "use client";
 import Button from "@/components/Button/Button";
 import useAlertModal from "@/hooks/useAlertModal";
+import { useModal } from "@/provider/contexts/ModalContext";
 import { useUserContext } from "@/provider/contexts/UserContext";
 import useKnowhowCommentMutation from "@/stores/queries/useKnowhowCommentMutation";
 import useVoteCommentMutation from "@/stores/queries/useVoteCommentMutation";
+import { useRouter } from "next/navigation";
 import { FormEventHandler, useRef } from "react";
 
 type CommentFormProps = {
@@ -13,6 +15,8 @@ type CommentFormProps = {
 
 function CommentForm({ postId, board }: CommentFormProps) {
   const { user } = useUserContext();
+  const modal = useModal();
+  const router = useRouter();
   const { displayDefaultAlert } = useAlertModal();
 
   const { addKnowhowComment } = useKnowhowCommentMutation();
@@ -20,8 +24,21 @@ function CommentForm({ postId, board }: CommentFormProps) {
 
   const commentInputRef = useRef<HTMLTextAreaElement>(null);
 
+  const handleOpenModal = () =>
+    modal.open({
+      type: "confirm",
+      content: "로그인 후 이용해 주세요.",
+      onConfirm: () => router.push("/login")
+    });
+
   const handleCommentSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
+
+    if (!user) {
+      handleOpenModal();
+      return;
+    }
+
     if (commentInputRef.current && postId && user) {
       if (!commentInputRef.current.value.trim()) {
         displayDefaultAlert("내용을 입력하세요.");

--- a/src/app/(main)/boards/_components/Comments/CommentForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentForm.tsx
@@ -48,10 +48,15 @@ function CommentForm({ postId, board }: CommentFormProps) {
   };
 
   return (
-    <form onSubmit={handleCommentSubmit} className="flex flex-col w-full">
-      <textarea ref={commentInputRef} className="h-[118px] rounded-xl border border-[#DCDCDC] resize-none mb-4" />
+    <form onSubmit={handleCommentSubmit} className="w-full flex flex-col gap-[19px]">
+      <textarea ref={commentInputRef} className="h-[90px] w-full bg-white border border-gray-800 resize-none" />
       <div className="flex justify-end">
-        <Button type="submit">댓글 등록</Button>
+        <Button
+          type="submit"
+          className="w-[83px] h-[42px] bg-gray-900 text-[#e1ff01] text-[13px] font-semibold leading-[30px] rounded-none"
+        >
+          작성하기
+        </Button>
       </div>
     </form>
   );

--- a/src/app/(main)/boards/_components/Comments/CommentItem.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentItem.tsx
@@ -11,6 +11,7 @@ import CommentActions from "@/app/(main)/boards/_components/Comments/CommentActi
 import CommentEditForm from "@/app/(main)/boards/_components/Comments/CommentEditForm";
 import useAlertModal from "@/hooks/useAlertModal";
 import useVoteCommentMutation from "@/stores/queries/useVoteCommentMutation";
+import Image from "next/image";
 
 type CommentItemPropsForKnowhow = {
   comment: TKnowhowComment;
@@ -78,20 +79,27 @@ function CommentItem({ comment, board }: CommentItemPropsForKnowhow | CommentIte
   };
 
   return (
-    <li className="mt-4 border rounded-xl px-5">
-      <div className="flex justify-between">
-        <span>{nickname}</span>
+    <li className="w-full h-24 flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-[7px]">
+            <div className="w-6 h-6 flex justify-center items-center">
+              <Image className="w-6 h-6 rounded-full" src="/path/to/image.jpg" alt="profile" width={24} height={24} />
+            </div>
+            <div className="text-black text-base font-semibold leading-snug">{nickname}</div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="text-[#acacac] text-sm font-normal leading-3">{formattedDate}</div>
+            <div className="text-[#acacac] text-sm font-normal leading-3">{formattedTime}</div>
+          </div>
+        </div>
         {!isEditing && user?.userId === comment?.user_id && (
           <CommentActions onEditModeChange={handleEditModeChange} onOpenModal={handleOpenModal} />
         )}
       </div>
       {!isEditing && (
         <>
-          <p>{content}</p>
-          <div>
-            <time>{formattedDate} </time>
-            <time>{formattedTime}</time>
-          </div>
+          <p className="w-full text-black text-base font-normal leading-normal">{content}</p>
         </>
       )}
       {isEditing && (

--- a/src/app/(main)/boards/_components/Comments/CommentItem.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentItem.tsx
@@ -1,5 +1,7 @@
 "use client";
+
 import { TKnowhowComment } from "@/types/knowhow.type";
+import { TVoteComment } from "@/types/vote.type";
 import { formatTime } from "@/app/(main)/boards/_utils";
 import useKnowhowCommentMutation from "@/stores/queries/useKnowhowCommentMutation";
 import { ChangeEventHandler, useState } from "react";
@@ -8,19 +10,30 @@ import { useUserContext } from "@/provider/contexts/UserContext";
 import CommentActions from "@/app/(main)/boards/_components/Comments/CommentActions";
 import CommentEditForm from "@/app/(main)/boards/_components/Comments/CommentEditForm";
 import useAlertModal from "@/hooks/useAlertModal";
+import useVoteCommentMutation from "@/stores/queries/useVoteCommentMutation";
 
-type CommentItemProps = {
+type CommentItemPropsForKnowhow = {
   comment: TKnowhowComment;
+  board: "knowhow" | "vote";
 };
 
-function CommentItem({ comment }: CommentItemProps) {
+type CommentItemPropsForVote = {
+  comment: TVoteComment;
+  board: "knowhow" | "vote";
+};
+
+function CommentItem({ comment, board }: CommentItemPropsForKnowhow | CommentItemPropsForVote) {
   const { user } = useUserContext();
   const modal = useModal();
   const { displayDefaultAlert } = useAlertModal();
   const { nickname, content, created_at } = comment;
-  const [isEditting, setIsEditting] = useState<boolean>(false);
-  const [editedContent, setEditedContent] = useState<TKnowhowComment["content"]>(content || "");
+
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [editedContent, setEditedContent] = useState<string>(content || "");
+
   const { updateKnowhowComment, removeKnowhowComment } = useKnowhowCommentMutation();
+  const { updateVoteComment, removeVoteComment } = useVoteCommentMutation();
+
   const { formattedDate, formattedTime } = formatTime(created_at);
 
   const handleOpenModal = () =>
@@ -29,33 +42,50 @@ function CommentItem({ comment }: CommentItemProps) {
       content: "댓글을 삭제하시겠습니까?",
       onConfirm: handleCommentDelete
     });
-  const handleEditModeChange = () => setIsEditting(true);
+
+  const handleEditModeChange = () => setIsEditing(true);
+
   const handleContentChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => setEditedContent(e.target.value);
-  const handleCommentDelete = () => removeKnowhowComment(comment);
+
+  const handleCommentDelete = () => {
+    if (board === "knowhow") {
+      removeKnowhowComment(comment as TKnowhowComment);
+    } else {
+      removeVoteComment(comment as TVoteComment);
+    }
+  };
+
   const handleCommentUpdate = async () => {
-    ``;
     const { nickname, ...commentWithoutNickname } = comment;
+
     if (!editedContent.trim().length) {
       displayDefaultAlert("내용을 입력하세요.");
       return;
     }
+
     const updatedComment = {
       ...commentWithoutNickname,
       content: editedContent
     };
-    await updateKnowhowComment(updatedComment);
-    setIsEditting(false);
+
+    if (board === "knowhow") {
+      await updateKnowhowComment(updatedComment as TKnowhowComment);
+    } else {
+      await updateVoteComment(updatedComment as TVoteComment);
+    }
+
+    setIsEditing(false);
   };
 
   return (
     <li className="mt-4 border rounded-xl px-5">
       <div className="flex justify-between">
         <span>{nickname}</span>
-        {!isEditting && user?.userId === comment?.user_id && (
+        {!isEditing && user?.userId === comment?.user_id && (
           <CommentActions onEditModeChange={handleEditModeChange} onOpenModal={handleOpenModal} />
         )}
       </div>
-      {!isEditting && (
+      {!isEditing && (
         <>
           <p>{content}</p>
           <div>
@@ -64,7 +94,7 @@ function CommentItem({ comment }: CommentItemProps) {
           </div>
         </>
       )}
-      {isEditting && (
+      {isEditing && (
         <CommentEditForm
           editedContent={editedContent}
           onContentChange={handleContentChange}

--- a/src/app/(main)/boards/_components/Comments/CommentsContainer.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentsContainer.tsx
@@ -17,10 +17,14 @@ function CommentsContainer({ postId, board }: CommentsContainerProps) {
   const comments = board === "knowhow" ? KnowhowComments : VoteComments;
 
   return (
-    <section className="px-[30px] w-full">
-      <span className="block text-[#444] text-xl mb-[15px]">댓글 {comments?.length || 0}개</span>
-      <CommentForm postId={postId} board={board} />
-      {comments && <CommentsList comments={comments} board={board} />}
+    <section className="w-[700px] flex flex-col gap-8">
+      <div className="w-full flex flex-col">
+        <div className="w-full h-[59px] px-1.5 py-4 flex flex-col">
+          <div className="w-full text-black text-lg font-normal leading-[27px]">댓글 {comments?.length || 0}</div>
+        </div>
+        <CommentForm postId={postId} board={board} />
+        {comments && <CommentsList comments={comments} board={board} />}
+      </div>
     </section>
   );
 }

--- a/src/app/(main)/boards/_components/Comments/CommentsContainer.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentsContainer.tsx
@@ -3,18 +3,24 @@
 import CommentForm from "@/app/(main)/boards/_components/Comments/CommentForm";
 import CommentsList from "@/app/(main)/boards/_components/Comments/CommentsList";
 import useKnowhowCommentsQuery from "@/stores/queries/useKnowhowCommentsQuery";
+import useVoteCommentsQuery from "@/stores/queries/useVoteCommentsQuery";
 
 type CommentsContainerProps = {
   postId: number;
+  board: "knowhow" | "vote";
 };
 
-function CommentsContainer({ postId }: CommentsContainerProps) {
-  const { data: comments } = useKnowhowCommentsQuery(postId);
+function CommentsContainer({ postId, board }: CommentsContainerProps) {
+  const { data: KnowhowComments } = useKnowhowCommentsQuery(postId);
+  const { data: VoteComments } = useVoteCommentsQuery(postId);
+
+  const comments = board === "knowhow" ? KnowhowComments : VoteComments;
+
   return (
     <section className="px-[30px] w-full">
       <span className="block text-[#444] text-xl mb-[15px]">댓글 {comments?.length || 0}개</span>
-      <CommentForm postId={postId} />
-      {comments && <CommentsList comments={comments} />}
+      <CommentForm postId={postId} board={board} />
+      {comments && <CommentsList comments={comments} board={board} />}
     </section>
   );
 }

--- a/src/app/(main)/boards/_components/Comments/CommentsList.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentsList.tsx
@@ -1,12 +1,28 @@
 import CommentItem from "@/app/(main)/boards/_components/Comments/CommentItem";
 import { TKnowhowComment } from "@/types/knowhow.type";
+import { TVoteComment } from "@/types/vote.type";
+
+function isKnowhowComment(comment: TKnowhowComment | TVoteComment): comment is TKnowhowComment {
+  return (comment as TKnowhowComment).knowhow_commentId !== undefined;
+}
 
 type CommentsListProps = {
-  comments: TKnowhowComment[];
+  comments: (TKnowhowComment | TVoteComment)[];
+  board: "knowhow" | "vote";
 };
 
-function CommentsList({ comments }: CommentsListProps) {
-  return <ul>{comments?.map((comment) => <CommentItem key={comment.knowhow_commentId} comment={comment} />)}</ul>;
+function CommentsList({ comments, board }: CommentsListProps) {
+  return (
+    <ul>
+      {comments.map((comment) =>
+        isKnowhowComment(comment) ? (
+          <CommentItem key={comment.knowhow_commentId} comment={comment} board={board} />
+        ) : (
+          <CommentItem key={comment.vote_commentId} comment={comment} board={board} />
+        )
+      )}
+    </ul>
+  );
 }
 
 export default CommentsList;

--- a/src/app/(main)/boards/_components/Comments/CommentsList.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentsList.tsx
@@ -13,7 +13,7 @@ type CommentsListProps = {
 
 function CommentsList({ comments, board }: CommentsListProps) {
   return (
-    <ul>
+    <ul className="w-full flex flex-col gap-9">
       {comments.map((comment) =>
         isKnowhowComment(comment) ? (
           <CommentItem key={comment.knowhow_commentId} comment={comment} board={board} />

--- a/src/app/(main)/boards/knowhow/[knowhowId]/page.tsx
+++ b/src/app/(main)/boards/knowhow/[knowhowId]/page.tsx
@@ -10,7 +10,7 @@ async function KnowhowDetailPage({ params: { knowhowId } }: { params: { knowhowI
     <main className="p-3">
       <PostContent knowhow={knowhow} />
       <PostActions knowhow={knowhow} />
-      <CommentsContainer postId={knowhowId} />
+      <CommentsContainer postId={knowhowId} board="knowhow" />
     </main>
   );
 }

--- a/src/app/(main)/boards/knowhow/_components/KnowhowContainer.tsx
+++ b/src/app/(main)/boards/knowhow/_components/KnowhowContainer.tsx
@@ -25,7 +25,7 @@ function KnowhowContainer() {
   const [searchKeyword, setSearchKeyword] = useState<string>("");
   const [currentPage, setCurrentPage] = useState<number>(1);
 
-  const { data: knowhows, refetch } = useKnowhowsQuery(
+  const { data: knowhows } = useKnowhowsQuery(
     currentPage,
     ITEMS_PER_PAGE,
     sortOrder,
@@ -33,10 +33,6 @@ function KnowhowContainer() {
     searchKeyword
   );
   const totalItems = knowhows?.posts[0]?.total_count;
-
-  useEffect(() => {
-    refetch();
-  }, [refetch]);
 
   const handleSortOrderChange = (value: TOption["value"]) => {
     setSortOrder(value);

--- a/src/app/(main)/boards/knowhow/_components/KnowhowContainer.tsx
+++ b/src/app/(main)/boards/knowhow/_components/KnowhowContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 import useKnowhowsQuery from "@/stores/queries/useKnowhowsQuery";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import KnowhowFilter from "@/app/(main)/boards/knowhow/_components/KnowhowFilter";
 import KnowhowPagination from "@/app/(main)/boards/knowhow/_components/KnowhowPagination";
 import { ITEMS_PER_PAGE, SEARCH_OPTIONS, SORT_OPTIONS, TOption } from "@/app/(main)/boards/knowhow/_constants";
@@ -24,7 +24,8 @@ function KnowhowContainer() {
   const [selectedSearchOption, setSelectedSearchOption] = useState<TOption["value"]>(SEARCH_OPTIONS[0].value);
   const [searchKeyword, setSearchKeyword] = useState<string>("");
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const { data: knowhows } = useKnowhowsQuery(
+
+  const { data: knowhows, refetch } = useKnowhowsQuery(
     currentPage,
     ITEMS_PER_PAGE,
     sortOrder,
@@ -32,6 +33,10 @@ function KnowhowContainer() {
     searchKeyword
   );
   const totalItems = knowhows?.posts[0]?.total_count;
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
 
   const handleSortOrderChange = (value: TOption["value"]) => {
     setSortOrder(value);

--- a/src/app/(main)/boards/votes/[voteId]/page.tsx
+++ b/src/app/(main)/boards/votes/[voteId]/page.tsx
@@ -1,6 +1,7 @@
 import { getVote } from "@/apis/votes";
 import VoteContent from "@/app/(main)/boards/votes/[voteId]/_components/VoteContent";
 import ActionNav from "@/app/(main)/boards/votes/[voteId]/_components/ActionNav";
+import CommentsContainer from "@/app/(main)/boards/_components/Comments/CommentsContainer";
 
 async function VoteDetailPage({ params: { voteId } }: { params: { voteId: number } }) {
   const vote = await getVote(voteId);
@@ -9,7 +10,7 @@ async function VoteDetailPage({ params: { voteId } }: { params: { voteId: number
     <main>
       <VoteContent vote={vote} />
       <ActionNav vote={vote} />
-      {/* CommentsContainer */}
+      <CommentsContainer postId={voteId} board="vote" />
     </main>
   );
 }

--- a/src/app/(main)/boards/votes/_components/VotesContainer.tsx
+++ b/src/app/(main)/boards/votes/_components/VotesContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import useVotesQuery from "@/stores/queries/useVotesQuery";
 import Button from "@/components/Button/Button";
 import SortButtons from "@/app/(main)/boards/votes/_components/SortButtons";
@@ -11,8 +11,12 @@ function VotesContainer() {
   const router = useRouter();
   const [sortOrder, setSortOrder] = useState("latest");
 
-  const { data, isLoading, fetchNextPage, hasNextPage } = useVotesQuery(sortOrder);
+  const { data, isLoading, fetchNextPage, hasNextPage, refetch } = useVotesQuery(sortOrder);
   const observer = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
 
   const handleWriteClick = () => {
     router.push(`/boards/votes/write`);

--- a/src/app/(main)/boards/votes/_components/VotesContainer.tsx
+++ b/src/app/(main)/boards/votes/_components/VotesContainer.tsx
@@ -11,12 +11,8 @@ function VotesContainer() {
   const router = useRouter();
   const [sortOrder, setSortOrder] = useState("latest");
 
-  const { data, isLoading, fetchNextPage, hasNextPage, refetch } = useVotesQuery(sortOrder);
+  const { data, isLoading, fetchNextPage, hasNextPage } = useVotesQuery(sortOrder);
   const observer = useRef<IntersectionObserver | null>(null);
-
-  useEffect(() => {
-    refetch();
-  }, [refetch]);
 
   const handleWriteClick = () => {
     router.push(`/boards/votes/write`);

--- a/src/app/api/votes/[voteId]/comments/route.ts
+++ b/src/app/api/votes/[voteId]/comments/route.ts
@@ -1,0 +1,74 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (req: NextRequest, { params }: { params: { voteId: string } }) => {
+  const supabase = createClient();
+  const voteId = params.voteId;
+
+  try {
+    if (voteId) {
+      const { data: comments, error: commentError } = await supabase
+        .from("vote_comments")
+        .select(
+          `
+          *,
+          users (nickname)
+        `
+        )
+        .eq("vote_post_id", voteId)
+        .order("created_at", { ascending: true });
+
+      if (commentError) {
+        throw new Error("댓글을 가져오지 못했습니다");
+      }
+
+      const commentsWithNickname = comments.map((comment) => {
+        const { users, ...commentData } = comment;
+        return {
+          ...commentData,
+          nickname: users?.nickname
+        };
+      });
+      return NextResponse.json({ comments: commentsWithNickname || [] });
+    } else {
+      return NextResponse.json({ error: "유효하지 않은 요청입니다" }, { status: 400 });
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      return NextResponse.json({ error: e.message }, { status: 500 });
+    } else {
+      return NextResponse.json({ error: "알 수 없는 에러가 발생했습니다" }, { status: 500 });
+    }
+  }
+};
+
+export const POST = async (req: NextRequest, { params }: { params: { voteId: string } }) => {
+  const supabase = createClient();
+  const voteId = params.voteId;
+  const newComment = await req.json();
+
+  console.log("POST: ", voteId);
+
+  try {
+    if (voteId) {
+      const { status, statusText, error } = await supabase
+        .from("vote_comments")
+        .insert({ ...newComment, vote_post_id: voteId })
+        .single();
+
+      if (error) {
+        throw new Error("댓글 작성에 실패했습니다");
+      }
+
+      return NextResponse.json({ status, statusText });
+    } else {
+      return NextResponse.json({ error: "유효하지 않은 요청입니다" }, { status: 400 });
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      return NextResponse.json({ error: e.message }, { status: 500 });
+    } else {
+      return NextResponse.json({ error: "알 수 없는 에러가 발생했습니다" }, { status: 500 });
+    }
+  }
+};

--- a/src/app/api/votes/comments/[commentId]/route.ts
+++ b/src/app/api/votes/comments/[commentId]/route.ts
@@ -1,0 +1,59 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+export const PATCH = async (req: NextRequest, { params }: { params: { voteId: string } }) => {
+  const supabase = createClient();
+  const commentId = params.voteId;
+  const updatedComment = await req.json();
+
+  try {
+    if (commentId) {
+      const { status, statusText, error } = await supabase
+        .from("vote_comments")
+        .update(updatedComment)
+        .eq("vote_commentId", commentId);
+
+      if (error) {
+        throw new Error("댓글 수정에 실패했습니다");
+      }
+
+      return NextResponse.json({ status, statusText });
+    } else {
+      return NextResponse.json({ error: "유효하지 않은 요청입니다" }, { status: 400 });
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      return NextResponse.json({ error: e.message }, { status: 500 });
+    } else {
+      return NextResponse.json({ error: "알 수 없는 에러가 발생했습니다" }, { status: 500 });
+    }
+  }
+};
+
+export const DELETE = async (req: NextRequest, { params }: { params: { commentId: string } }) => {
+  const supabase = createClient();
+  const commentId = params.commentId;
+
+  try {
+    if (commentId) {
+      const { status, statusText, error } = await supabase
+        .from("vote_comments")
+        .delete()
+        .eq("vote_commentId", commentId);
+
+      if (error) {
+        throw new Error("댓글 삭제에 실패했습니다");
+      }
+
+      return NextResponse.json({ status, statusText });
+    } else {
+      return NextResponse.json({ error: "유효하지 않은 요청입니다" }, { status: 400 });
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      return NextResponse.json({ error: e.message }, { status: 500 });
+    } else {
+      return NextResponse.json({ error: "알 수 없는 에러가 발생했습니다" }, { status: 500 });
+    }
+  }
+};

--- a/src/app/api/votes/comments/[commentId]/route.ts
+++ b/src/app/api/votes/comments/[commentId]/route.ts
@@ -1,9 +1,9 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 
-export const PATCH = async (req: NextRequest, { params }: { params: { voteId: string } }) => {
+export const PATCH = async (req: NextRequest, { params }: { params: { commentId: string } }) => {
   const supabase = createClient();
-  const commentId = params.voteId;
+  const commentId = params.commentId;
   const updatedComment = await req.json();
 
   try {

--- a/src/stores/queries/useKnowhowCommentMutation.ts
+++ b/src/stores/queries/useKnowhowCommentMutation.ts
@@ -1,5 +1,6 @@
 import { deleteKnowhowComment, patchKnowhowComment, postKnowhowComment } from "@/apis/knowhow";
 import useAlertModal from "@/hooks/useAlertModal";
+import { DEFAULT_KNOWHOWS_QUERY_KEY } from "@/stores/queries/useKnowhowMutation";
 import { TResponseStatus } from "@/types/knowhow.type";
 import { Tables } from "@/types/supabase";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -12,6 +13,9 @@ const useKnowhowCommentMutation = () => {
     onSuccess: (status, updatedComment) => {
       queryClient.invalidateQueries({
         queryKey: ["knowhowComments", { knowhowId: updatedComment.knowhow_post_id?.toString() }]
+      });
+      queryClient.invalidateQueries({
+        queryKey: DEFAULT_KNOWHOWS_QUERY_KEY
       });
     },
     onError: (e) => displayDefaultAlert(e.message)

--- a/src/stores/queries/useVoteCommentMutation.ts
+++ b/src/stores/queries/useVoteCommentMutation.ts
@@ -1,0 +1,44 @@
+import { deleteVoteComment, patchVoteComment, postVoteComment } from "@/apis/votes";
+import useAlertModal from "@/hooks/useAlertModal";
+import { TResponseStatus } from "@/types/knowhow.type";
+import { Tables } from "@/types/supabase";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const useVoteCommentMutation = () => {
+  const { displayDefaultAlert } = useAlertModal();
+  const queryClient = useQueryClient();
+
+  const { mutateAsync: addVoteComment } = useMutation<TResponseStatus, Error, Partial<Tables<"vote_comments">>>({
+    mutationFn: (updatedComment) => postVoteComment(updatedComment),
+    onSuccess: (status, updatedComment) => {
+      queryClient.invalidateQueries({
+        queryKey: ["voteComments", { voteId: updatedComment.vote_post_id?.toString() }]
+      });
+    },
+    onError: (e) => displayDefaultAlert(e.message)
+  });
+
+  const { mutateAsync: updateVoteComment } = useMutation<TResponseStatus, Error, Partial<Tables<"vote_comments">>>({
+    mutationFn: (updatedComment) => patchVoteComment(updatedComment),
+    onSuccess: (status, updatedComment) => {
+      queryClient.invalidateQueries({
+        queryKey: ["voteComments", { voteId: updatedComment?.vote_post_id?.toString() }]
+      });
+    },
+    onError: (e) => displayDefaultAlert(e.message)
+  });
+
+  const { mutateAsync: removeVoteComment } = useMutation<TResponseStatus, Error, Tables<"vote_comments">>({
+    mutationFn: (comment) => deleteVoteComment(comment.vote_commentId),
+    onSuccess: (status, comment) => {
+      queryClient.invalidateQueries({
+        queryKey: ["voteComments", { voteId: comment.vote_post_id.toString() }]
+      });
+    },
+    onError: (e) => displayDefaultAlert(e.message)
+  });
+
+  return { addVoteComment, updateVoteComment, removeVoteComment };
+};
+
+export default useVoteCommentMutation;

--- a/src/stores/queries/useVoteCommentMutation.ts
+++ b/src/stores/queries/useVoteCommentMutation.ts
@@ -14,6 +14,9 @@ const useVoteCommentMutation = () => {
       queryClient.invalidateQueries({
         queryKey: ["voteComments", { voteId: updatedComment.vote_post_id?.toString() }]
       });
+      queryClient.invalidateQueries({
+        queryKey: ["votes"]
+      });
     },
     onError: (e) => displayDefaultAlert(e.message)
   });

--- a/src/stores/queries/useVoteCommentsQuery.ts
+++ b/src/stores/queries/useVoteCommentsQuery.ts
@@ -1,0 +1,12 @@
+import { getVoteComments } from "@/apis/votes";
+import { TVoteComment } from "@/types/vote.type";
+import { useQuery } from "@tanstack/react-query";
+
+const useVoteCommentsQuery = (voteId: number) => {
+  return useQuery<TVoteComment[], Error>({
+    queryKey: ["voteComments", { voteId }],
+    queryFn: () => getVoteComments(voteId)
+  });
+};
+
+export default useVoteCommentsQuery;

--- a/src/types/vote.type.ts
+++ b/src/types/vote.type.ts
@@ -22,3 +22,7 @@ export type TVoteWithNavigation = TVote & {
   prevVoteId?: number | null;
   nextVoteId?: number | null;
 };
+
+export type TVoteComment = Tables<"vote_comments"> & {
+  nickname?: Tables<"users">["nickname"];
+};


### PR DESCRIPTION
## 변경 사항:

 - 댓글 관련 컴포넌트 리팩토링
 - 짠 소비 댓글 UI
-  짠 소비 댓글 CRUD 구현
-  비로그인 상태에서 짠 소비 댓글 등록 버튼 클릭할 경우 로그인 페이지로 리다이렉션
-  댓글 등록 후 목록으로 이동했을 때 업데이트된 댓글 개수를 가져오지 못하는 문제를 해결하기 위해 Container에서 refetch를 사용해봤는데 서버에 부하가 가는 방법인 것 같아 고민입니다. 좋은 방법이 있다면 알려주세요!

## 변경 유형

- [x] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [x] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [x] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [x] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈

- close #108 
