### PR TITLE
feat: 모달 우측상단 X버튼 추가, 버튼의 텍스트를 변경할수 있도록 수정, 모달 UI작업

### DIFF
--- a/public/icons/x_btn.svg
+++ b/public/icons/x_btn.svg
@@ -1,0 +1,4 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.3334 4.66663L4.66675 23.3333" stroke="#555555" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M23.3334 23.3333L4.66675 4.66663" stroke="#555555" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/app/(main)/boards/knowhow/_components/KnowhowContainer.tsx
+++ b/src/app/(main)/boards/knowhow/_components/KnowhowContainer.tsx
@@ -15,6 +15,7 @@ import SearchOptions from "@/app/(main)/boards/knowhow/_components/SearchOptions
 import { useRouter, useSearchParams } from "next/navigation";
 import Button from "@/components/Button/Button";
 import { useModal } from "@/provider/contexts/ModalContext";
+import useAlertModal from "@/hooks/useAlertModal";
 
 const KnowhowList = dynamic(() => import("@/app/(main)/boards/knowhow/_components/KnowhowList"), {
   loading: () => (
@@ -29,7 +30,8 @@ const KnowhowList = dynamic(() => import("@/app/(main)/boards/knowhow/_component
 });
 
 function KnowhowContainer() {
-  const modal = useModal();
+  const { displayDefaultAlert } = useAlertModal();
+  const { open } = useModal();
   const router = useRouter();
   const [sortOrder, setSortOrder] = useState<TOption["value"]>(SORT_OPTIONS[0].value);
   const [selectedSearchOption, setSelectedSearchOption] = useState<TOption["value"]>(SEARCH_OPTIONS[0].value);

--- a/src/components/Modal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal.tsx
@@ -1,16 +1,14 @@
 import Button from "@/components/Button/Button";
+import DefaultModalTemplate from "@/components/Modal/DefaultModalTemplate";
 import { AlertModalProps } from "@/types/modal.type";
 
-function AlertModal({ content, subContent, onClose }: AlertModalProps) {
+function AlertModal({ content, subContent, buttonContent, onClose }: AlertModalProps) {
   return (
-    <div>
-      <h6 className="text-center">{content}</h6>
-      {subContent && <p className="text-center">{subContent}</p>}
-      <div className="flex justify-center items-center">
-        <Button onClick={onClose}>확인</Button>
-      </div>
-    </div>
+    <DefaultModalTemplate content={content} subContent={subContent}>
+      <Button className="w-[400px] h-[74px] px-5 py-3 rounded-e-xl text-xl" onClick={onClose}>
+        {buttonContent || "확인"}
+      </Button>
+    </DefaultModalTemplate>
   );
 }
-
 export default AlertModal;

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -1,16 +1,19 @@
 import Button from "@/components/Button/Button";
+import DefaultModalTemplate from "@/components/Modal/DefaultModalTemplate";
 import { ConfirmModalProps } from "@/types/modal.type";
 
-function ConfirmModal({ content, subContent, onConfirm, onCancel }: ConfirmModalProps) {
+function ConfirmModal({ content, subContent, buttonContent, onConfirm, onCancel }: ConfirmModalProps) {
   return (
-    <div>
-      <h6 className="text-center">{content}</h6>
-      {subContent && <p>{subContent}</p>}
-      <div className="flex w-full justify-evenly mt-8">
-        <Button onClick={onCancel}>취소</Button>
-        <Button onClick={onConfirm}>확인</Button>
+    <DefaultModalTemplate content={content} subContent={subContent}>
+      <div className="flex gap-5">
+        <Button className="w-[190px] h-[74px] rounded-xl" bgColor="white" onClick={onCancel}>
+          취소
+        </Button>
+        <Button className="w-[190px] h-[74px] rounded-xl" onClick={onConfirm}>
+          {buttonContent || "확인"}
+        </Button>
       </div>
-    </div>
+    </DefaultModalTemplate>
   );
 }
 

--- a/src/components/Modal/DefaultModalTemplate.tsx
+++ b/src/components/Modal/DefaultModalTemplate.tsx
@@ -1,0 +1,23 @@
+import { Children, ReactNode } from "react";
+
+type DefaultModalTemplateProps = {
+  content: string;
+  subContent?: string;
+  children: ReactNode;
+};
+
+function DefaultModalTemplate({ content, subContent, children }: DefaultModalTemplateProps) {
+  return (
+    <div>
+      <div className="flex flex-col mt-[82px] text-xl text-[#1b1b1b] font-semibold gap-3">
+        <p className="text-center">{content}</p>
+        {subContent && <p className="text-center">{subContent}</p>}
+      </div>
+      <div className="flex justify-center items-center  absolute bottom-[30px] right-1/2 translate-x-1/2 text-xl font-bold ">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default DefaultModalTemplate;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -4,8 +4,12 @@ import BackDrop from "@/components/Modal/BackDrop";
 import ConfirmModal from "@/components/Modal/ConfirmModal";
 import NicknameModal from "@/components/Modal/NicknameModal";
 import { ModalProps, ConfirmModalProps, AlertModalProps, NicknameModalProps } from "@/types/modal.type";
+import xBtn from "/public/icons/x_btn.svg";
+import Image from "next/image";
+import { useModal } from "@/provider/contexts/ModalContext";
 
 const Modal = (props: ModalProps) => {
+  const { close } = useModal();
   const renderModal = () => {
     switch (props.type) {
       case "confirm":
@@ -16,6 +20,7 @@ const Modal = (props: ModalProps) => {
             content={confirmProps.content}
             subContent={confirmProps.subContent || ""}
             onConfirm={confirmProps.onConfirm}
+            buttonContent={confirmProps.buttonContent}
             onCancel={confirmProps.onCancel || (() => {})}
           />
         );
@@ -26,6 +31,7 @@ const Modal = (props: ModalProps) => {
             type={alertProps.type}
             content={alertProps.content}
             subContent={alertProps.subContent || ""}
+            buttonContent={alertProps.buttonContent}
             onClose={alertProps.onClose || (() => {})}
           />
         );
@@ -39,8 +45,18 @@ const Modal = (props: ModalProps) => {
 
   return (
     <BackDrop>
-      <div className="relative bg-white p-10 rounded min-w-[340px]">
-        <article className="px-6 py-2 text-lg">{renderModal()}</article>
+      <div className="relative px-[50px] bg-white rounded-3xl min-w-[500px] min-h-[300px]">
+        <article className=" text-lg">
+          <Image
+            onClick={close}
+            className="absolute cursor-pointer top-5 right-4"
+            src={xBtn}
+            alt="x_btn"
+            width={28}
+            height={28}
+          />
+          {renderModal()}
+        </article>
       </div>
     </BackDrop>
   );

--- a/src/hooks/useAlertModal.ts
+++ b/src/hooks/useAlertModal.ts
@@ -3,13 +3,15 @@ import { useModal } from "@/provider/contexts/ModalContext";
 const useAlertModal = () => {
   const { open, isOpen } = useModal();
 
-  const displayDefaultAlert = (content: string) => {
+  const displayDefaultAlert = (content: string, subContent?: string, buttonContent?: string) => {
     if (isOpen) {
       return;
     }
     open({
       type: "alert",
-      content
+      content,
+      subContent,
+      buttonContent
     });
   };
 

--- a/src/provider/contexts/ModalContext.tsx
+++ b/src/provider/contexts/ModalContext.tsx
@@ -60,6 +60,7 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
           content={"content" in modalOptions ? modalOptions.content : ""}
           subContent={"subContent" in modalOptions ? modalOptions.subContent : ""}
           onConfirm={modalOptions.type === "confirm" ? handleConfirm : () => {}}
+          buttonContent={"buttonContent" in modalOptions ? modalOptions.buttonContent : ""}
           onCancel={modalOptions.type === "confirm" ? handleCancel : () => {}}
           onClose={modalOptions.type === "alert" || modalOptions.type === "nickname" ? handleClose : () => {}}
         />

--- a/src/types/modal.type.ts
+++ b/src/types/modal.type.ts
@@ -4,6 +4,7 @@ export type ConfirmModalProps = {
   type: "confirm";
   content: string;
   subContent?: string;
+  buttonContent?: string;
   onConfirm: () => void;
   onCancel?: () => void;
 };
@@ -12,6 +13,7 @@ export type AlertModalProps = {
   type: "alert";
   content: string;
   subContent?: string;
+  buttonContent?: string;
   onClose?: () => void;
 };
 


### PR DESCRIPTION
## 변경 사항:


useModal 의 open
---
- 모달 우측상단에 모달을 닫을 수 있는 X버튼을 추가했습니다.
`open` 함수에서 `buttonContent` 를 추가로 받도록 했습니다 

 확인버튼의 텍스트내용이며 전달하지 않을경우 “확인” 이 기본으로 표시됩니다.

```jsx
 <Button
        onClick={() =>
          open({
            type: "confirm",
            content: "정말 지웁니까?",
            subContent: "진짜 지워요?",
            onConfirm: () => alert("지웠어요"),
            buttonContent: "삭제"
          })
        }
      >
       삭제하는버튼
      </Button>
```
![image](https://github.com/user-attachments/assets/0eaa6d9c-fe95-4fca-9e08-185013d24a3d)

displayDefaultAlert
---
- useAlertModal 훅으로 불러올 수 있는 `displayDefaultAlert` 에 인자 두개를 추가로 받을 수 있도록 했습니다

```jsx
  const displayDefaultAlert = (content: string, subContent?: string, buttonContent?: string) => {
```

첫번째 인자는 기존과 동일하게 첫번째 줄의 텍스트입니다

두번째 인자는 텍스트의 두번째 줄이며 옵셔널합니다

세번째 인자는 확인버튼의 텍스트내용이며 전달하지 않을경우 “확인” 이 기본으로 표시됩니다.

세가지 인자 모두 string으로 전달 해 주세요.


## 변경 유형

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [ ] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [x] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [x] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

