### PR TITLE
design: 메인 레이아웃 패딩바텀 추가 / 짠노하우 짠 소비평가 UI  / 포인트 페이지 로딩스피너 적용

### DIFF
--- a/src/app/(main)/boards/_components/BoardDescription.tsx
+++ b/src/app/(main)/boards/_components/BoardDescription.tsx
@@ -4,17 +4,12 @@ type BoardDescriptionProps = {
   title: string;
   description: string;
   children: ReactNode;
-  board: "knowhow" | "vote";
 };
 
-function BoardDescription({ title, description, children, board }: BoardDescriptionProps) {
+function BoardDescription({ title, description, children }: BoardDescriptionProps) {
   return (
     <>
-      <section
-        className={`w-full h-[120px] py-[29px] flex-col justify-start items-start gap-2.5 inline-flex ${
-          board === "vote" ? "px-[30px] bg-[#d9d9d9]" : ""
-        }`}
-      >
+      <section className="w-full h-[120px] py-[29px] flex-col mb-6 justify-start items-start gap-2.5 inline-flex px-[30px]">
         <div className="flex-col justify-start items-start gap-3.5 flex">
           <h1 className="self-stretch h-[29px] text-black text-2xl font-semibold">{title}</h1>
           <p className="w-[495px] text-black text-base font-normal">{description}</p>

--- a/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentEditForm.tsx
@@ -18,7 +18,8 @@ function CommentEditForm({
   return (
     <form className="w-full flex flex-col gap-3">
       <textarea
-        className="h-[90px] pl-[19px] pr-[481px] pt-3.5 pb-[52px] bg-white rounded-lg border border-[#8b8b8b] justify-start items-center inline-flex scrollbar-hide"
+        maxLength={500}
+        className="h-[90px] px-[19px] pt-3.5 pb-[52px] bg-white rounded-lg border border-[#8b8b8b] justify-start items-center inline-flex scrollbar-hide"
         value={editedContent}
         onChange={handleContentChange}
       />

--- a/src/app/(main)/boards/_components/Comments/CommentForm.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentForm.tsx
@@ -62,7 +62,8 @@ function CommentForm({ postId, board }: CommentFormProps) {
     <form onSubmit={handleCommentSubmit} className="w-full flex flex-col gap-[12px]">
       <textarea
         ref={commentInputRef}
-        className="h-[90px] pl-[19px] pr-[481px] pt-3.5 pb-[52px] bg-white rounded-lg border border-[#8b8b8b] justify-start items-center inline-flex scrollbar-hide"
+        maxLength={500}
+        className="h-[90px] px-[19px] pt-3.5 pb-[52px] bg-white rounded-lg border border-[#8b8b8b] justify-start items-center inline-flex scrollbar-hide"
       />
       <div className="flex justify-end mb-[36px]">
         <button

--- a/src/app/(main)/boards/_components/Comments/CommentItem.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentItem.tsx
@@ -81,8 +81,8 @@ function CommentItem({ comment, board }: CommentItemPropsForKnowhow | CommentIte
   };
 
   return (
-    <li className="w-full flex flex-col gap-3">
-      <div className="flex items-center justify-between">
+    <li className="w-full flex flex-col gap-3　">
+      <div className="flex items-center justify-between ">
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-[7px]">
             <div className="w-6 h-6 flex justify-center items-center relative aspect-square">
@@ -101,7 +101,9 @@ function CommentItem({ comment, board }: CommentItemPropsForKnowhow | CommentIte
       </div>
       {!isEditing && (
         <>
-          <p className="w-full text-black text-base font-normal leading-normal">{content}</p>
+          <p className="w-full text-black text-base font-normal leading-normal break-words whitespace-pre-wrap">
+            {content}
+          </p>
         </>
       )}
       {isEditing && (

--- a/src/app/(main)/boards/_components/Comments/CommentsList.tsx
+++ b/src/app/(main)/boards/_components/Comments/CommentsList.tsx
@@ -13,7 +13,9 @@ type CommentsListProps = {
 
 function CommentsList({ comments, board }: CommentsListProps) {
   return (
-    <ul className="w-full flex flex-col gap-[40px]">
+    <ul
+      className={`w-full flex flex-col gap-[40px]   ${board === "knowhow" && comments[0] && "bg-[#f6f5f1] p-6 rounded-2xl"}`}
+    >
       {comments.map((comment) =>
         isKnowhowComment(comment) ? (
           <CommentItem key={comment.knowhow_commentId} comment={comment} board={board} />

--- a/src/app/(main)/boards/knowhow/_constants/index.ts
+++ b/src/app/(main)/boards/knowhow/_constants/index.ts
@@ -35,4 +35,4 @@ export const EXCHANGE_FILTER_OPTION = [
   { value: CLAIM, label: "교환내역" }
 ];
 
-export const MAX_CONTENT_LENGTH = 1000;
+export const MAX_CONTENT_LENGTH = 10000;

--- a/src/app/(main)/boards/knowhow/page.tsx
+++ b/src/app/(main)/boards/knowhow/page.tsx
@@ -7,7 +7,6 @@ function KnowhowPage() {
     <BoardDescription
       title="짠 노하우를 공유해요!"
       description="특가 상품, 절약 노하우, 재테크 방법 짠-노하우를 공유해 보세요."
-      board="knowhow"
     >
       <Suspense>
         <KnowhowContainer />

--- a/src/app/(main)/boards/votes/[voteId]/_components/VoteContent.tsx
+++ b/src/app/(main)/boards/votes/[voteId]/_components/VoteContent.tsx
@@ -34,10 +34,11 @@ function VoteContent({ vote }: VoteContentProps) {
           </div>
           <div className="w-[436px] flex flex-col justify-start items-center gap-8">
             <div className="w-full flex flex-col gap-6">
-              <div className="relative w-full h-[300px] overflow-hidden">
+              <div className="relative w-full h-[300px] overflow-hidden group">
                 <Image src={image_url} alt="게시글 이미지" className="rounded-xl object-cover" layout="fill" />
-                <div className="hover:opacity-0 transition-all duration-300 absolute inset-0 bg-gradient-to-t from-black to-transparent rounded-xl"></div>
-                <div className="absolute bottom-4 right-[20px] text-right text-white text-base font-normal">
+                <div className="transition-opacity duration-300 absolute inset-0 rounded-xl group-hover:opacity-0 bg-[linear-gradient(to_top,rgba(0,0,0,0.7),transparent_30%)]"></div>
+
+                <div className="absolute bottom-4 right-[20px] text-right text-white  text-base font-normal transition-opacity duration-300 group-hover:opacity-0">
                   <div>{product_name}</div>
                   <div>{product_price.toLocaleString()} 원</div>
                 </div>

--- a/src/app/(main)/boards/votes/[voteId]/_components/VoteContent.tsx
+++ b/src/app/(main)/boards/votes/[voteId]/_components/VoteContent.tsx
@@ -36,7 +36,7 @@ function VoteContent({ vote }: VoteContentProps) {
             <div className="w-full flex flex-col gap-6">
               <div className="relative w-full h-[300px] overflow-hidden">
                 <Image src={image_url} alt="게시글 이미지" className="rounded-xl object-cover" layout="fill" />
-                <div className="absolute inset-0 bg-gradient-to-t from-black to-transparent rounded-xl"></div>
+                <div className="hover:opacity-0 transition-all duration-300 absolute inset-0 bg-gradient-to-t from-black to-transparent rounded-xl"></div>
                 <div className="absolute bottom-4 right-[20px] text-right text-white text-base font-normal">
                   <div>{product_name}</div>
                   <div>{product_price.toLocaleString()} 원</div>

--- a/src/app/(main)/boards/votes/page.tsx
+++ b/src/app/(main)/boards/votes/page.tsx
@@ -3,11 +3,10 @@ import VotesContainer from "@/app/(main)/boards/votes/_components/VotesContainer
 
 function VotesPage() {
   return (
-    <div className="w-[1120px] h-[2296px] flex-col justify-start items-start gap-6 inline-flex">
+    <div className="w-[1120px] h-[2296px] flex-col justify-start items-start  inline-flex">
       <BoardDescription
         title="다른 사람의 소비를 구경해 보아요"
         description="소비 내역을 공유하고 함께 좋은 소비였는지 아쉬운 소비였는지 평가해 보아요"
-        board="vote"
       >
         <VotesContainer />
       </BoardDescription>

--- a/src/app/(main)/exchange/_components/GiftList.tsx
+++ b/src/app/(main)/exchange/_components/GiftList.tsx
@@ -7,7 +7,7 @@ type GiftListProps = {
 
 function GiftList({ gifts }: GiftListProps) {
   return (
-    <ul className="grid mb-10  grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-[15px] gap-y-8">
+    <ul className="grid   grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-[15px] gap-y-8">
       {gifts.map((gift) => (
         <GiftItem key={gift.giftId} gift={gift} />
       ))}

--- a/src/app/(main)/mypage/_components/Points/MyPointsHistoryTable.tsx
+++ b/src/app/(main)/mypage/_components/Points/MyPointsHistoryTable.tsx
@@ -6,6 +6,8 @@ import { formatTime } from "@/app/(main)/boards/_utils";
 import { Suspense, useState } from "react";
 import Pagination from "@/app/(main)/boards/knowhow/_components/Pagination";
 import { useSearchParams } from "next/navigation";
+import LoadingSpinner from "@/components/Loading/LoadingSpinner";
+import SmallLoadingSpinner from "@/components/Loading/SmallLoadinSpinner";
 
 function MyPointsHistoryTable() {
   const { user } = useUserContext();
@@ -22,7 +24,7 @@ function MyPointsHistoryTable() {
   const handlePageChange = (page: number) => setCurrentPage(page);
 
   if (isLoading) {
-    return <div>로딩 중...</div>;
+    return <SmallLoadingSpinner />;
   }
 
   if (!points || points.length === 0) {

--- a/src/app/(main)/mypage/_components/Points/MyPointsHistoryTable.tsx
+++ b/src/app/(main)/mypage/_components/Points/MyPointsHistoryTable.tsx
@@ -30,7 +30,7 @@ function MyPointsHistoryTable() {
   }
 
   return (
-    <div className="w-[924px] mb-[120px]">
+    <div className="w-[924px] ">
       <table className="w-full border-collapse">
         <thead className="border-t border-basic">
           <tr className="flex w-full justify-between items-center">

--- a/src/app/(main)/mypage/point/loading.tsx
+++ b/src/app/(main)/mypage/point/loading.tsx
@@ -1,0 +1,7 @@
+import LoadingSpinner from "@/components/Loading/LoadingSpinner";
+
+function loading() {
+  return <LoadingSpinner />;
+}
+
+export default loading;

--- a/src/app/(main)/mypage/point/page.tsx
+++ b/src/app/(main)/mypage/point/page.tsx
@@ -6,9 +6,7 @@ function MyPointDetailPage() {
   return (
     <section className="w-[933.08px] flex flex-col items-center justify-center gap-16 mx-auto">
       <MyCurrentPoints />
-      <Suspense>
-        <MyPointsHistoryTable />
-      </Suspense>
+      <MyPointsHistoryTable />
     </section>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <link rel="icon" href="/favicon.png" sizes="any" />
-      <body className="max-w-[1120px] mx-auto">
+      <body className="max-w-[1120px] pb-[100px] mx-auto">
         <Providers>
           <HeaderContainer />
           {children}


### PR DESCRIPTION
## 변경 사항:

- [메인 레이아웃에 패딩바텀 적용](https://github.com/ZZANTech/ZZANTech-Fe/issues/198)
- [BoardDescription 배경색 제거, 바텀에 마진추가, 패딩 있는버전으로 통일](https://github.com/ZZANTech/ZZANTech-Fe/issues/200)
- [댓글 작성시 보이는 폼의 절반도 공간을 사용하지 않는 문제 해결](https://github.com/ZZANTech/ZZANTech-Fe/issues/204)
- [댓글 내용이 댓글 아이템 공간을 벗어나는 공간 수정](https://github.com/ZZANTech/ZZANTech-Fe/issues/205)
- [짠 노하우 및 소비평가 댓글 최대 500자로 변경](https://github.com/ZZANTech/ZZANTech-Fe/issues/203)
- [짠 노하우 댓글에 배경색 적용](https://github.com/ZZANTech/ZZANTech-Fe/issues/199)
- [소비평가 이미지 호버시 그라데이션 제거](https://github.com/ZZANTech/ZZANTech-Fe/issues/201)
- [포인트 내역 로딩스피너 적용](https://github.com/ZZANTech/ZZANTech-Fe/issues/202)

## 변경 유형

- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [ ] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [ ] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [ ] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [ ] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈

- close #198
- close #199 
- close #200
- close #201
- close #202
- close #203
- close #204
- close #205

