### PR TITLE
fix: 게시글 작성, 수정, 기프티콘 구매시 중복요청 방지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.44.4",
         "@tanstack/react-query": "^5.51.5",
         "@tanstack/react-query-devtools": "^5.51.5",
+        "clsx": "^2.1.1",
         "dayjs": "^1.11.12",
         "immer": "^10.1.1",
         "next": "14.2.5",
@@ -1937,6 +1938,14 @@
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cmd-shim": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@supabase/supabase-js": "^2.44.4",
     "@tanstack/react-query": "^5.51.5",
     "@tanstack/react-query-devtools": "^5.51.5",
+    "clsx": "^2.1.1",
     "dayjs": "^1.11.12",
     "immer": "^10.1.1",
     "next": "14.2.5",

--- a/src/app/(main)/exchange/_components/GiftItem.tsx
+++ b/src/app/(main)/exchange/_components/GiftItem.tsx
@@ -23,6 +23,7 @@ function GiftItem({ gift }: GiftItemProps) {
   const formattedPoint = formatNumberWithCommas(gift.point);
   const router = useRouter();
   const handleExchange = async () => {
+    if (isPending) return;
     const newExchange = {
       gift_id: gift.giftId,
       user_id: user?.userId

--- a/src/app/(main)/exchange/_components/GiftItem.tsx
+++ b/src/app/(main)/exchange/_components/GiftItem.tsx
@@ -9,6 +9,7 @@ import point from "/public/icons/point.png";
 import { formatNumberWithCommas } from "@/app/(main)/boards/_utils";
 import useAlertModal from "@/hooks/useAlertModal";
 import useExchangeMutation from "@/stores/queries/exchange/useExchangeMutation";
+import LoadingSpinner from "@/components/Loading/LoadingSpinner";
 
 type GiftItemProps = {
   gift: Tables<"gifts">;
@@ -18,7 +19,7 @@ function GiftItem({ gift }: GiftItemProps) {
   const { user } = useUserContext();
   const { open } = useModal();
   const { displayLoginAlert } = useAlertModal();
-  const { addClaim } = useExchangeMutation();
+  const { addClaim, isPending } = useExchangeMutation();
   const formattedPoint = formatNumberWithCommas(gift.point);
   const router = useRouter();
   const handleExchange = async () => {
@@ -65,11 +66,13 @@ function GiftItem({ gift }: GiftItemProps) {
         <span className="text-[#FF6000] font-semibold">{formattedPoint}P</span>
       </div>
       <button
+        disabled={isPending}
         className="flex justify-center font-semibold rounded-lg items-center text-white w-[236px] bg-[#FF6000] h-10 p-4 box-border"
         onClick={handleOpenConfirmModal}
       >
         교환버튼
       </button>
+      {isPending && <LoadingSpinner isSubmitting />}
     </li>
   );
 }

--- a/src/components/Loading/LoadingSpinner.tsx
+++ b/src/components/Loading/LoadingSpinner.tsx
@@ -1,12 +1,28 @@
 import Image from "next/image";
 import React from "react";
+import clsx from "clsx";
 
-function LoadingSpinner() {
+type LoadingSpinnerProps = {
+  isSubmitting?: boolean;
+};
+
+function LoadingSpinner({ isSubmitting = false }: LoadingSpinnerProps) {
   return (
-    <div className="flex items-center justify-center h-screen">
-      <div className="relative w-28 h-28">
-        <div className="absolute inset-0 border-[15px] border-orange-200 rounded-full" />
-        <Image src="/icons/Spiner.svg" alt="Loading Spinner" className="animate-spin" width={112} height={112} />
+    <div
+      className={clsx("fixed inset-0 z-50 flex items-center justify-center", {
+        "bg-black bg-opacity-20 pointer-events-auto select-none": isSubmitting,
+        "pointer-events-none": !isSubmitting
+      })}
+    >
+      <div className="relative w-28 h-28 pointer-events-none">
+        <div className="absolute inset-0 border-[15px] border-orange-200 rounded-full pointer-events-none" />
+        <Image
+          src="/icons/Spiner.svg"
+          alt="Loading Spinner"
+          className="animate-spin pointer-events-none"
+          width={112}
+          height={112}
+        />
       </div>
     </div>
   );

--- a/src/stores/queries/exchange/useExchangeMutation.ts
+++ b/src/stores/queries/exchange/useExchangeMutation.ts
@@ -7,7 +7,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 const useExchangeMutation = () => {
   const queryClient = useQueryClient();
   const { displayDefaultAlert } = useAlertModal();
-  const { mutateAsync: addClaim } = useMutation<TResponseStatus, Error, Partial<Tables<"gift_claims">>>({
+  const { mutateAsync: addClaim, isPending } = useMutation<TResponseStatus, Error, Partial<Tables<"gift_claims">>>({
     mutationFn: (newClaim) => postClaim(newClaim),
     onSuccess: (data, newClaim) => {
       displayDefaultAlert("교환 신청이 완료되었습니다", "1일~3일 이내에 발송될 예정입니다");
@@ -17,6 +17,6 @@ const useExchangeMutation = () => {
     },
     onError: (e) => displayDefaultAlert(e.message)
   });
-  return { addClaim };
+  return { addClaim, isPending };
 };
 export default useExchangeMutation;

--- a/src/stores/queries/knowhow/post/useKnowhowMutation.ts
+++ b/src/stores/queries/knowhow/post/useKnowhowMutation.ts
@@ -23,7 +23,11 @@ const useKnowhowMutation = () => {
 
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { mutateAsync: addKnowhow } = useMutation<TResponseStatus, Error, Partial<Tables<"knowhow_posts">>>({
+  const { mutateAsync: addKnowhow, isPending: isPostPending } = useMutation<
+    TResponseStatus,
+    Error,
+    Partial<Tables<"knowhow_posts">>
+  >({
     mutationFn: (newKnowhow) => postKnowhow(newKnowhow),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -34,7 +38,11 @@ const useKnowhowMutation = () => {
     onError: (e) => displayDefaultAlert(e.message)
   });
 
-  const { mutateAsync: updateKnowhow } = useMutation<TResponseStatus, Error, Partial<Tables<"knowhow_posts">>>({
+  const { mutateAsync: updateKnowhow, isPatchPending } = useMutation<
+    TResponseStatus,
+    Error,
+    Partial<Tables<"knowhow_posts">>
+  >({
     mutationFn: (updatedKnowhow) => patchKnowhow(updatedKnowhow),
     onSuccess: (status, updatedKnowhow) => {
       queryClient.invalidateQueries({
@@ -58,7 +66,7 @@ const useKnowhowMutation = () => {
       onError: (e) => displayDefaultAlert(e.message)
     }
   );
-  return { addKnowhow, updateKnowhow, removeKnowhow };
+  return { addKnowhow, updateKnowhow, isPostPending, isPatchPending, removeKnowhow };
 };
 
 export default useKnowhowMutation;

--- a/src/stores/queries/knowhow/post/useKnowhowMutation.ts
+++ b/src/stores/queries/knowhow/post/useKnowhowMutation.ts
@@ -38,7 +38,7 @@ const useKnowhowMutation = () => {
     onError: (e) => displayDefaultAlert(e.message)
   });
 
-  const { mutateAsync: updateKnowhow, isPatchPending } = useMutation<
+  const { mutateAsync: updateKnowhow, isPending: isPatchPending } = useMutation<
     TResponseStatus,
     Error,
     Partial<Tables<"knowhow_posts">>

--- a/src/stores/queries/vote/post/useVoteMutation.ts
+++ b/src/stores/queries/vote/post/useVoteMutation.ts
@@ -9,7 +9,11 @@ const useVoteMutation = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const { mutateAsync: addVote } = useMutation<TVotesResponse, Error, Partial<Tables<"vote_posts">>>({
+  const { mutateAsync: addVote, isPending: isPostPending } = useMutation<
+    TVotesResponse,
+    Error,
+    Partial<Tables<"vote_posts">>
+  >({
     mutationFn: (newVote) => postVote(newVote),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -19,7 +23,11 @@ const useVoteMutation = () => {
     }
   });
 
-  const { mutateAsync: updateVote } = useMutation<TVotesResponse, Error, Partial<Tables<"vote_posts">>>({
+  const { mutateAsync: updateVote, isPending: isPatchPending } = useMutation<
+    TVotesResponse,
+    Error,
+    Partial<Tables<"vote_posts">>
+  >({
     mutationFn: (updatedVote) => patchVote(updatedVote),
     onSuccess: (status, updatedVote) => {
       queryClient.invalidateQueries({
@@ -40,7 +48,7 @@ const useVoteMutation = () => {
     }
   });
 
-  return { addVote, updateVote, removeVote };
+  return { addVote, isPostPending, updateVote, isPatchPending, removeVote };
 };
 
 export default useVoteMutation;


### PR DESCRIPTION
## 변경 사항:

- submit 로직중 이미 submit된 상태라면 바로 return합니다
- submit 도중에 로딩스피너를 돌립니다
- 로딩스피너에 `isSubmitting` prop 을 추가했습니다.

## 변경 유형

- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [ ] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [ ] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [ ] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [ ] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈

- close #이슈번호
