### PR TITLE
fix: 유저정보 변경시 유저 refetch

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,4 @@
-import { TChangePassword } from "@/types/user.type";
+import { TChangePassword, TUser } from "@/types/user.type";
 import { Dispatch, SetStateAction } from "react";
 import { BASE_URL } from "@/constants";
 import { TUserInsert } from "@/types/user.type";
@@ -28,6 +28,15 @@ export async function signUp(data: TUserInsert) {
 
   return response.json();
 }
+
+export const fetchUser = async (): Promise<TUser | null> => {
+  const response = await fetch(`${BASE_URL}/api/auth/me`, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error("Failed to fetch user");
+  }
+  const data = await response.json();
+  return data.users || null;
+};
 
 //마이페이지 : 중복확인 및 update API
 export const updateNickname = async (

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -31,9 +31,6 @@ export async function signUp(data: TUserInsert) {
 
 export const fetchUser = async (): Promise<TUser | null> => {
   const response = await fetch(`${BASE_URL}/api/auth/me`, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error("Failed to fetch user");
-  }
   const data = await response.json();
   return data.users || null;
 };

--- a/src/app/(main)/mypage/_components/MypageContainer.tsx
+++ b/src/app/(main)/mypage/_components/MypageContainer.tsx
@@ -6,9 +6,17 @@ import MyPostsContainer from "@/app/(main)/mypage/_components/MyPostsContainer";
 import OtherPostsContainer from "@/app/(main)/mypage/_components/OtherPostsContainer";
 import LoadingSpinner from "@/components/Loading/LoadingSpinner";
 import { useUserContext } from "@/provider/contexts/UserContext";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import useUserQuery from "@/stores/queries/auth/useUserQuery";
 
 function MypageContainer() {
   const { user } = useUserContext();
+  const { refetch } = useUserQuery();
+
+  useEffect(() => {
+    refetch();
+  }, []);
 
   if (!user) return <LoadingSpinner />;
   return (

--- a/src/components/Modal/NicknameModal.tsx
+++ b/src/components/Modal/NicknameModal.tsx
@@ -3,14 +3,16 @@
 import { updateNickname } from "@/apis/auth";
 import { useModal } from "@/provider/contexts/ModalContext";
 import { useUserContext } from "@/provider/contexts/UserContext";
+import useUserQuery from "@/stores/queries/auth/useUserQuery";
 import { checkNicknameValidity } from "@/utils/authValidity";
+import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 function NicknameModal() {
   const { user } = useUserContext();
   const email = user?.email;
   const oldNickname = user?.nickname;
-
+  const queryClient = useQueryClient();
   const [nickname, setNickname] = useState<string>(oldNickname || "");
   const [nicknameError, setNicknameError] = useState<string>("");
   const [isNicknameValid, setIsNicknameValid] = useState<boolean | null>(null);
@@ -24,6 +26,7 @@ function NicknameModal() {
     if (!nicknameError) {
       const res = await updateNickname(nickname, email || "", setNicknameError, setIsNicknameValid);
       if (res.ok) {
+        queryClient.invalidateQueries();
         open({
           type: "alert",
           content: "닉네임 변경이 완료되었습니다"

--- a/src/provider/contexts/UserContext.tsx
+++ b/src/provider/contexts/UserContext.tsx
@@ -3,7 +3,9 @@
 import { logout } from "@/apis/auth";
 import { fetchQuizStatus } from "@/apis/quiz";
 import { BASE_URL } from "@/constants";
+import useUserQuery from "@/stores/queries/auth/useUserQuery";
 import { TUser } from "@/types/user.type";
+import { useQueryClient } from "@tanstack/react-query";
 import { createContext, useContext, useEffect, useState } from "react";
 
 type UserContextType = {
@@ -26,7 +28,9 @@ const UserContext = createContext<UserContextType>({
 export const useUserContext = () => useContext(UserContext);
 
 const UserProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<TUser | null>(null);
+  const queryClient = useQueryClient();
+  const { data: user = null, isPending, refetch } = useUserQuery();
+  // const [user, setUser] = useState<TUser | null>(null);
   const [hasTakenQuiz, setHasTakenQuiz] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -36,11 +40,11 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
     const data = await response.json();
     const users = data.users;
     if (users) {
-      setUser(users);
+      // setUser(users);
       const quizStatus = await fetchQuizStatus();
       setHasTakenQuiz(quizStatus.hasTakenQuiz);
     } else {
-      setUser(null);
+      // setUser(null);
       setHasTakenQuiz(false);
     }
     setIsLoading(false);
@@ -54,7 +58,8 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
         body: JSON.stringify({ email, password })
       });
       if (response.ok) {
-        await fetchUser();
+        // await fetchUser();
+        refetch();
       } else {
         const errorData = await response.json();
         throw new Error(errorData.error || "로그인 실패");
@@ -68,7 +73,10 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const logOut = async () => {
     setIsLoading(true);
     await logout();
-    setUser(null);
+    // setUser(null);
+    // queryClient.invalidateQueries({
+    //   queryKey: ["user"]
+    // });
     setHasTakenQuiz(false);
     setIsLoading(false);
   };

--- a/src/provider/contexts/UserContext.tsx
+++ b/src/provider/contexts/UserContext.tsx
@@ -40,11 +40,9 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
     const data = await response.json();
     const users = data.users;
     if (users) {
-      // setUser(users);
       const quizStatus = await fetchQuizStatus();
       setHasTakenQuiz(quizStatus.hasTakenQuiz);
     } else {
-      // setUser(null);
       setHasTakenQuiz(false);
     }
     setIsLoading(false);
@@ -58,7 +56,6 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
         body: JSON.stringify({ email, password })
       });
       if (response.ok) {
-        // await fetchUser();
         refetch();
       } else {
         const errorData = await response.json();
@@ -73,10 +70,9 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const logOut = async () => {
     setIsLoading(true);
     await logout();
-    // setUser(null);
-    // queryClient.invalidateQueries({
-    //   queryKey: ["user"]
-    // });
+    queryClient.invalidateQueries({
+      queryKey: ["user"]
+    });
     setHasTakenQuiz(false);
     setIsLoading(false);
   };

--- a/src/stores/queries/auth/useUserQuery.ts
+++ b/src/stores/queries/auth/useUserQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { TUser } from "@/types/user.type";
+import { fetchUser } from "@/apis/auth";
+
+const useUserQuery = () => {
+  return useQuery<TUser | null>({
+    queryKey: ["user"],
+    queryFn: fetchUser
+  });
+};
+export default useUserQuery;


### PR DESCRIPTION
## 변경 사항:

- 유저 데이터 패칭을 TanStack Query로 관리하도록 변경
- 닉네임 변경시, 마이페이지에 접근시 유저 정보를 refetch

## 변경 유형

- [x] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [ ] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [x] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [x] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈

- close #247 
