### PR TITLE
Moblie/auth: 로그인 페이지 카카오 이미지 오류 해결, 마이페이지(등급제) 모바일 반응형 구축(1)

### DIFF
--- a/src/app/(auth)/login/_components/LogInContainer.tsx
+++ b/src/app/(auth)/login/_components/LogInContainer.tsx
@@ -125,8 +125,8 @@ function LogInContainer() {
         className="mb-3"
         onClick={() => handleSocialLogin("kakao")}
       >
-        <Image src={"/logos/kakao_black.png"} width={25} height={25} alt="kakao_black" />
-        카카오로 계속하기
+        <Image src={"/logos/Kakao_black.png"} width={25} height={25} alt="kakao_black" />
+        <p className="pl-1">카카오로 계속하기</p>
       </Button>
 
       <Button
@@ -137,7 +137,7 @@ function LogInContainer() {
         onClick={() => handleSocialLogin("google")}
       >
         <Image src={"/logos/Google_color.png"} width={25} height={25} alt="Google_color" />
-        Google로 계속하기
+        <p className="pl-1">Google로 계속하기</p>
       </Button>
 
       <div className="flex flex-row gap-2.5 w-[340px] font-sm items-center justify-center mt-3">

--- a/src/app/(main)/mypage/_components/Grade/GradeInfo.tsx
+++ b/src/app/(main)/mypage/_components/Grade/GradeInfo.tsx
@@ -22,9 +22,9 @@ function GradeInfo({ onClose }: GradeInfoProps) {
   ];
 
   return (
-    <div className="p-10">
+    <div className="lg:p-10">
+      <h3 className="hidden lg:block text-center text-xl font-semibold mb-3">등급제란?</h3>
       <section className="flex flex-col items-center">
-        <h3 className="text-xl font-semibold mb-3">등급제란?</h3>
         <p className="text-sm text-center mb-6">
           짠테커에서는 다섯 등급에 따라 뱃지가 부여됩니다.
           <br /> 등급을 올리기 위해서는 일정 포인트가 필요합니다.
@@ -33,26 +33,26 @@ function GradeInfo({ onClose }: GradeInfoProps) {
         </p>
       </section>
       <section className="mb-11">
-        <div className="flex mb-2">
-          <div className="font-semibold pl-6">레벨</div>
-          <div className="font-semibold pl-11">뱃지</div>
+        <div className="flex pb-2 mb-2 border-b-2 border-gray-900">
+          <div className="font-semibold pl-5">레벨</div>
+          <div className="font-semibold pl-11 lg:pl-11">뱃지</div>
           <div className="font-semibold pl-12">등급명</div>
-          <div className="font-semibold pl-20">달성 포인트</div>
+          <div className="font-semibold pl-20 lg:pl-20">달성 포인트</div>
         </div>
         {levels.map((level, index) => (
-          <div key={index} className="flex mb-2 pl-3 items-center">
+          <div key={index} className="flex mb-2 pl-3 py-2 items-center border-b border-gray-300">
             <div className="w-12 h-7 bg-main text-sm font-semibold leading-tight rounded-lg flex justify-center items-center">
               {level.level}
             </div>
-            <div className="pl-7">
+            <div className="pl-6">
               <Image src={level.badge} alt={level.name} width={36} height={36} />
             </div>
             <div className="pl-6 flex-1 text-[##262626]">{level.name}</div>
-            <div className="w-14 text-left pl-2 text-[##262626]">{level.points}</div>
+            <div className="w-14 text-left text-[##262626]">{level.points}</div>
           </div>
         ))}
       </section>
-      <section className="flex flex-col items-center mb-16">
+      <section className="flex flex-col items-center mb-8 lg:mb-16">
         <h3 className="text-xl font-semibold mb-4">포인트 모으는 방법</h3>
         <p className="text-center text-sm mb-6">
           하루에 모을 수 있는 포인트는 <span className="text-point">최대 1000P </span>입니다.
@@ -66,6 +66,7 @@ function GradeInfo({ onClose }: GradeInfoProps) {
           ))}
         </ul>
       </section>
+
       <div className="flex justify-center">
         <Button onClick={onClose} variant="black" fullWidth={true} size="large">
           확인

--- a/src/app/(main)/mypage/_components/Grade/GradeInfoContainer.tsx
+++ b/src/app/(main)/mypage/_components/Grade/GradeInfoContainer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import GradeInfo from "./GradeInfo";
 import { useRouter } from "next/navigation";
 
@@ -11,7 +12,16 @@ function GradeInfoContainer() {
   };
 
   return (
-    <div>
+    <div className="relative lg:px-4 lg:py-6 flex flex-col justify-start w-full h-full">
+      {/* 작은 화면에서만 보이는 뒤로가기 버튼과 "등급제란?" */}
+      <div className="lg:hidden flex items-center justify-between my-8">
+        <button onClick={handleClose}>
+          <Image src="/icons/quiz/back.svg" alt="뒤로가기" width={24} height={24} className="ml-5" />
+        </button>
+        <h3 className="text-lg font-bold flex-grow text-center pr-12">등급제란?</h3>
+      </div>
+
+      {/*등급제 내용*/}
       <GradeInfo onClose={handleClose} />
     </div>
   );

--- a/src/app/(main)/mypage/_components/Grade/GradeModal.tsx
+++ b/src/app/(main)/mypage/_components/Grade/GradeModal.tsx
@@ -13,9 +13,9 @@ function GradeModal({ children }: { children: React.ReactNode }) {
   return (
     <div
       onClick={handleBackdropClick}
-      className="fixed left-0 top-0 right-0 bottom-0 flex justify-center items-center bg-black bg-opacity-20 backdrop-blur-sm"
+      className="fixed left-0 top-0 right-0 bottom-0 flex justify-start lg:justify-center items-start lg:items-center bg-white lg:bg-black lg:bg-opacity-20 lg:backdrop-blur-sm overflow-y-auto mb-20 lg:mb-0"
     >
-      <div className="w-dvw h-dvh max-w-[500px] max-h-[778px] mx-4 md:mx-0 border bg-white rounded-3xl flex flex-col justify-center items-center">
+      <div className="max-w-none lg:w-dvw lg:h-dvh lg:max-w-[500px] mx-4 md:mx-0 border-none lg:border bg-white rouned-none lg:rounded-3xl flex flex-col justify-center items-center">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## 변경 사항:

- 베포된 링크의 로그인페이지에서 카카오 이미지가 안 보이는 문제 발생. 확인 결과 public 파일명(대문자 KaKao)과 이미지 src경로(소문자 kakao) 차이로 보임
- 마이페이지(등급제) : 모바일 반응형 구축, 도표처럼 보이는 div의 하단 밑줄 추가

## 변경 유형

- [x] 버그 수정
- [ ] 신규 기능
- [x] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [ ] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [x] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [x] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈

- close #이슈번호
